### PR TITLE
Feat/#20 get calendar

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarEventController.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarEventController.java
@@ -44,8 +44,8 @@ public class CalendarEventController {
             log.error("일정 등록 실패", e);
             return ResponseEntity.badRequest().body(
                     ApiResponse.onFailure(
-                            ErrorStatus.CREATE_EVENT_FAILED.getCode(),
-                            ErrorStatus.CREATE_EVENT_FAILED.getMessage() + ": " + e.getMessage(),
+                            ErrorStatus.EVENT_CREATE_FAILED.getCode(),
+                            ErrorStatus.EVENT_CREATE_FAILED.getMessage() + ": " + e.getMessage(),
                             null)
             );
         }
@@ -72,8 +72,8 @@ public class CalendarEventController {
         } catch (Exception e) {
             log.error("일정 수정 실패", e);
             ApiResponse<UpdateEventResponseDto> apiResponse = ApiResponse.onFailure(
-                    ErrorStatus.UPDATE_EVENT_FAILED.getCode(),
-                    ErrorStatus.UPDATE_EVENT_FAILED.getMessage() + ": " + e.getMessage(),
+                    ErrorStatus.EVENT_UPDATE_FAILED.getCode(),
+                    ErrorStatus.EVENT_UPDATE_FAILED.getMessage() + ": " + e.getMessage(),
                     null
             );
             return ResponseEntity.badRequest().body(apiResponse);
@@ -98,8 +98,8 @@ public class CalendarEventController {
             log.error("일정 삭제 실패", e);
 
             ApiResponse<Void> apiResponse = ApiResponse.onFailure(
-                    ErrorStatus.DELETE_EVENT_FAILED.getCode(),
-                    ErrorStatus.DELETE_EVENT_FAILED.getMessage() + ": " + e.getMessage(),
+                    ErrorStatus.EVENT_DELETE_FAILED.getCode(),
+                    ErrorStatus.EVENT_DELETE_FAILED.getMessage() + ": " + e.getMessage(),
                     null
             );
             return ResponseEntity.badRequest().body(apiResponse);

--- a/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarEventController.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarEventController.java
@@ -4,9 +4,11 @@ import com.indayvidual.server.domain.calendar.converter.EventConverter;
 import com.indayvidual.server.domain.calendar.dto.request.CreateEventRequestDto;
 import com.indayvidual.server.domain.calendar.dto.request.UpdateEventRequestDto;
 import com.indayvidual.server.domain.calendar.dto.response.CreateEventResponseDto;
+import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.UpdateEventResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
 import com.indayvidual.server.domain.calendar.service.EventCommandService;
+import com.indayvidual.server.domain.calendar.service.EventQueryService;
 import com.indayvidual.server.global.api.code.status.ErrorStatus;
 import com.indayvidual.server.global.api.code.status.SuccessStatus;
 import com.indayvidual.server.global.api.response.ApiResponse;
@@ -16,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/calendar/events")
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ public class CalendarEventController {
 
     private final EventCommandService eventCommandService;
     private final EventConverter eventConverter;
+    private final EventQueryService eventQueryService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateEventResponseDto>> createEvent(
@@ -100,6 +105,33 @@ public class CalendarEventController {
             ApiResponse<Void> apiResponse = ApiResponse.onFailure(
                     ErrorStatus.EVENT_DELETE_FAILED.getCode(),
                     ErrorStatus.EVENT_DELETE_FAILED.getMessage() + ": " + e.getMessage(),
+                    null
+            );
+            return ResponseEntity.badRequest().body(apiResponse);
+        }
+    }
+
+    @GetMapping("/{year}/{month}")
+    public ResponseEntity<ApiResponse<List<GetMonthlyCalendarResponseDto>>> getMonthlyCalendar(
+            @PathVariable int year,
+            @PathVariable int month) {
+
+        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+
+        try {
+            List<GetMonthlyCalendarResponseDto> calendar = eventQueryService.getMonthlyCalendar(year, month, userId);
+
+            return ResponseEntity.ok(ApiResponse.onSuccess(
+                    calendar,
+                    SuccessStatus.GET_CALENDAR_SUCCESS.getCode(),
+                    SuccessStatus.GET_CALENDAR_SUCCESS.getMessage())
+            );
+        } catch (Exception e) {
+            log.error("월별 캘린더 조회 실패", e);
+
+            ApiResponse<List<GetMonthlyCalendarResponseDto>> apiResponse = ApiResponse.onFailure(
+                    ErrorStatus.CALENDAR_FETCH_FAILED.getCode(),
+                    ErrorStatus.CALENDAR_FETCH_FAILED.getMessage() + ": " + e.getMessage(),
                     null
             );
             return ResponseEntity.badRequest().body(apiResponse);

--- a/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarEventController.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarEventController.java
@@ -4,6 +4,7 @@ import com.indayvidual.server.domain.calendar.converter.EventConverter;
 import com.indayvidual.server.domain.calendar.dto.request.CreateEventRequestDto;
 import com.indayvidual.server.domain.calendar.dto.request.UpdateEventRequestDto;
 import com.indayvidual.server.domain.calendar.dto.response.CreateEventResponseDto;
+import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.UpdateEventResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -132,6 +134,32 @@ public class CalendarEventController {
             ApiResponse<List<GetMonthlyCalendarResponseDto>> apiResponse = ApiResponse.onFailure(
                     ErrorStatus.CALENDAR_FETCH_FAILED.getCode(),
                     ErrorStatus.CALENDAR_FETCH_FAILED.getMessage() + ": " + e.getMessage(),
+                    null
+            );
+            return ResponseEntity.badRequest().body(apiResponse);
+        }
+    }
+
+    @GetMapping("/events/{date}")
+    public ResponseEntity<ApiResponse<List<GetDayEventResponseDto>>>  getDayEvents(@PathVariable String date) {
+
+        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+
+        try {
+            LocalDate eventDate = LocalDate.parse(date);
+            List<GetDayEventResponseDto> events = eventQueryService.getDayEvents(eventDate, userId);
+
+            return ResponseEntity.ok(
+                    ApiResponse.onSuccess(events,
+                            SuccessStatus.GET_DAY_EVENTS_SUCCESS.getCode(),
+                            SuccessStatus.GET_DAY_EVENTS_SUCCESS.getMessage())
+            );
+        } catch (Exception e) {
+            log.error("특정 날짜 일정 조회 실패", e);
+
+            ApiResponse<List<GetDayEventResponseDto>> apiResponse = ApiResponse.onFailure(
+                    ErrorStatus.EVENT_GET_BY_DATE_FAILED.getCode(),
+                    ErrorStatus.EVENT_GET_BY_DATE_FAILED.getMessage() + ": " + e.getMessage(),
                     null
             );
             return ResponseEntity.badRequest().body(apiResponse);

--- a/src/main/java/com/indayvidual/server/domain/calendar/converter/EventConverter.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/converter/EventConverter.java
@@ -3,12 +3,17 @@ package com.indayvidual.server.domain.calendar.converter;
 import com.indayvidual.server.domain.calendar.dto.request.CreateEventRequestDto;
 import com.indayvidual.server.domain.calendar.dto.request.UpdateEventRequestDto;
 import com.indayvidual.server.domain.calendar.dto.response.CreateEventResponseDto;
+import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.UpdateEventResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
 import org.springframework.stereotype.Component;
 
+import java.time.format.DateTimeFormatter;
+
 @Component
 public class EventConverter {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public Event toEntity(CreateEventRequestDto request, Long userId) {
         boolean hasEndTime = request.getEndTime() != null;
@@ -57,6 +62,17 @@ public class EventConverter {
         if (request.getColor() != null) {
             entity.setColorCode(request.getColor());
         }
+    }
+
+    public GetDayEventResponseDto toGetDayEventResponse(Event event) {
+        return GetDayEventResponseDto.builder()
+                .eventId(event.getId())
+                .type("event")
+                .title(event.getTitle())
+                .startTime(event.getStartTime().format(TIME_FORMATTER))
+                .endTime(event.getEndTime() != null ? event.getEndTime().format(TIME_FORMATTER) : null)
+                .color(event.getColorCode())
+                .build();
     }
 
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetDayEventResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetDayEventResponseDto.java
@@ -1,0 +1,25 @@
+package com.indayvidual.server.domain.calendar.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetDayEventResponseDto {
+
+    private Long eventId;
+
+    private String type;
+
+    private String title;
+
+    private String startTime;
+
+    private String endTime;
+
+    private String color;
+}

--- a/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetMonthlyCalendarResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetMonthlyCalendarResponseDto.java
@@ -1,0 +1,23 @@
+package com.indayvidual.server.domain.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetMonthlyCalendarResponseDto {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private Boolean hasEvent;
+
+    private Boolean hasTodo;
+}

--- a/src/main/java/com/indayvidual/server/domain/calendar/repository/EventRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/repository/EventRepository.java
@@ -2,8 +2,12 @@ package com.indayvidual.server.domain.calendar.repository;
 
 import com.indayvidual.server.domain.calendar.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +18,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     void deleteByIdAndUserId(Long id, Long userId);
 
     boolean existsByIdAndUserId(Long id, Long userId);
+
+    @Query("SELECT DISTINCT e.eventDate FROM Event e WHERE e.userId = :userId AND " + "e.eventDate >= :startDate AND e.eventDate <= :endDate")
+    List<LocalDate> findEventDatesByUserIdAndDateRange(@Param("userId") Long userId,
+                                                       @Param("startDate") LocalDate startDate,
+                                                       @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/repository/EventRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/repository/EventRepository.java
@@ -23,4 +23,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<LocalDate> findEventDatesByUserIdAndDateRange(@Param("userId") Long userId,
                                                        @Param("startDate") LocalDate startDate,
                                                        @Param("endDate") LocalDate endDate);
+
+    List<Event> findByUserIdAndEventDateOrderByStartTimeAsc(Long userId, LocalDate eventDate);
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryService.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryService.java
@@ -1,8 +1,13 @@
 package com.indayvidual.server.domain.calendar.service;
 
+import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
+
+import java.util.List;
 
 public interface EventQueryService {
     Event findByIdAndUserId(Long eventId, Long userId);
     boolean existsByIdAndUserId(Long eventId, Long userId);
+
+    List<GetMonthlyCalendarResponseDto> getMonthlyCalendar(int year, int month, Long userId);
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryService.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryService.java
@@ -1,8 +1,10 @@
 package com.indayvidual.server.domain.calendar.service;
 
+import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface EventQueryService {
@@ -10,4 +12,5 @@ public interface EventQueryService {
     boolean existsByIdAndUserId(Long eventId, Long userId);
 
     List<GetMonthlyCalendarResponseDto> getMonthlyCalendar(int year, int month, Long userId);
+    List<GetDayEventResponseDto> getDayEvents(LocalDate date, Long userId);
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.indayvidual.server.domain.calendar.service;
 
+import com.indayvidual.server.domain.calendar.converter.EventConverter;
+import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
 import com.indayvidual.server.domain.calendar.repository.EventRepository;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 public class EventQueryServiceImpl implements EventQueryService {
 
     private final EventRepository eventRepository;
+    private final EventConverter eventConverter;
 
     @Override
     public Event findByIdAndUserId(Long eventId, Long userId) {
@@ -56,5 +59,14 @@ public class EventQueryServiceImpl implements EventQueryService {
             currentDate = currentDate.plusDays(1);
         }
         return result;
+    }
+
+    @Override
+    public List<GetDayEventResponseDto> getDayEvents(LocalDate date, Long userId) {
+        List<Event> events = eventRepository.findByUserIdAndEventDateOrderByStartTimeAsc(userId, date);
+
+        return events.stream()
+                .map(eventConverter::toGetDayEventResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/service/EventQueryServiceImpl.java
@@ -1,10 +1,18 @@
 package com.indayvidual.server.domain.calendar.service;
 
+import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
 import com.indayvidual.server.domain.calendar.entity.Event;
 import com.indayvidual.server.domain.calendar.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,5 +30,31 @@ public class EventQueryServiceImpl implements EventQueryService {
     @Override
     public boolean existsByIdAndUserId(Long eventId, Long userId) {
         return eventRepository.existsByIdAndUserId(eventId, userId);
+    }
+
+    @Override
+    public List<GetMonthlyCalendarResponseDto> getMonthlyCalendar(int year, int month, Long userId) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        List<LocalDate> eventDates = eventRepository.findEventDatesByUserIdAndDateRange(userId, startDate, endDate);
+        Set<LocalDate> eventDateSet = eventDates.stream().collect(Collectors.toSet());
+
+        // TODO: 할일 기능 구현 후 할일 날짜 조회
+        // Set<LocalDate> todoDataSet = todoRepository.findTodoDatesByUserIdAndDateRange(userId, startDate, endDate);
+
+        List<GetMonthlyCalendarResponseDto> result = new ArrayList<>();
+        LocalDate currentDate = startDate;
+
+        while (!currentDate.isAfter(endDate)) {
+            result.add(GetMonthlyCalendarResponseDto.builder()
+                    .date(currentDate)
+                    .hasEvent(eventDateSet.contains(currentDate))
+                    .hasTodo(false) // TODO: 할일 기능 구현 후 수정 - todoDateSet.contains(currentDate)
+                    .build());
+            currentDate = currentDate.plusDays(1);
+        }
+        return result;
     }
 }

--- a/src/main/java/com/indayvidual/server/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/indayvidual/server/global/api/code/status/ErrorStatus.java
@@ -58,6 +58,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	USER_PASSWORD_CHANGE_FAILED(HttpStatus.BAD_REQUEST, "USER4002", "비밀번호 변경에 실패했습니다."),
 	USER_INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "USER4003", "비밀번호 형식이 올바르지 않습니다."),
 
+	// ===== 캘린더 관련 에러 (CALENDAR) =====
+	CALENDAR_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CAL5001", "월별 캘린더 정보 조회에 실패했습니다."),
+
 	// ===== 일정 관련 에러 (EVENT) =====
 	EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT4041", "일정을 찾을 수 없습니다."),
 	EVENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "EVENT4031", "일정에 접근할 권한이 없습니다."),

--- a/src/main/java/com/indayvidual/server/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/indayvidual/server/global/api/code/status/ErrorStatus.java
@@ -59,7 +59,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	USER_INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "USER4003", "비밀번호 형식이 올바르지 않습니다."),
 
 	// ===== 캘린더 관련 에러 (CALENDAR) =====
-	CALENDAR_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CAL5001", "월별 캘린더 정보 조회에 실패했습니다."),
+	CALENDAR_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CAL4001", "월별 캘린더 정보 조회에 실패했습니다."),
 
 	// ===== 일정 관련 에러 (EVENT) =====
 	EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT4041", "일정을 찾을 수 없습니다."),
@@ -72,6 +72,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	EVENT_DELETE_FAILED(HttpStatus.BAD_REQUEST, "EVENT4003", "일정 삭제에 실패했습니다."),
 	EVENT_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "EVENT4004", "유효하지 않은 날짜 범위입니다."),
 	EVENT_PAST_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EVENT4005", "과거 날짜에는 일정을 생성할 수 없습니다."),
+	EVENT_GET_BY_DATE_FAILED(HttpStatus.BAD_REQUEST, "EVENT4006", "특정 날짜 일정 조회에 실패했습니다."),
 
 	// ===== 파일 관련 에러 (FILE) =====
 	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE4041", "파일을 찾을 수 없습니다."),

--- a/src/main/java/com/indayvidual/server/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/indayvidual/server/global/api/code/status/SuccessStatus.java
@@ -18,7 +18,10 @@ public enum SuccessStatus implements BaseCode {
     // 일정 관련 응답
     CREATE_EVENT_SUCCESS(HttpStatus.OK, "CREATE_EVENT_SUCCESS", "일정 등록 성공"),
     UPDATE_EVENT_SUCCESS(HttpStatus.OK, "UPDATE_EVENT_SUCCESS", "일정 수정 성공"),
-    DELETE_EVENT_SUCCESS(HttpStatus.OK, "DELETE_EVENT_SUCCESS", "일정 삭제 성공")
+    DELETE_EVENT_SUCCESS(HttpStatus.OK, "DELETE_EVENT_SUCCESS", "일정 삭제 성공"),
+
+    // 캘린더 관련 응답
+    GET_CALENDAR_SUCCESS(HttpStatus.OK, "GET_CALENDAR_SUCCESS", "월별 캘린더 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/indayvidual/server/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/indayvidual/server/global/api/code/status/SuccessStatus.java
@@ -21,7 +21,8 @@ public enum SuccessStatus implements BaseCode {
     DELETE_EVENT_SUCCESS(HttpStatus.OK, "DELETE_EVENT_SUCCESS", "일정 삭제 성공"),
 
     // 캘린더 관련 응답
-    GET_CALENDAR_SUCCESS(HttpStatus.OK, "GET_CALENDAR_SUCCESS", "월별 캘린더 조회 성공")
+    GET_CALENDAR_SUCCESS(HttpStatus.OK, "GET_CALENDAR_SUCCESS", "월별 캘린더 조회 성공"),
+    GET_DAY_EVENTS_SUCCESS(HttpStatus.OK, "GET_DAY_EVENTS_SUCCESS", "특정 날짜 일정 조회 성공"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
캘린더 조회 관련 API들을 구현했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #20 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 월별 캘린더 조회 
  - 월 단위로 달력 전체 날짜에 대해 일정 및 투두 포함 여부를 반환하는 API 구현
  -  투두 데이터는 관련 API 구현 후 반영 예정(현재는 `hasTodo = false`로 고정)
  - 프론트와 협의 후, 전체 날짜를 다 주고, 각 날짜별로 할일/투두 여부를 알려주는 방식으로 조회하도록 함
- 특정 날짜 일정 조회 

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 리팩토링 예정
   - calendar, event 도메인 분리
   - JWT에서 user id 추출 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 