### PR TITLE
[BUG] springdoc 설정 application-prod.yml에 명시적 추가 #29

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,6 +39,12 @@ spring:
 server:
   port: 8080
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+
 logging:
   level:
     com.indayvidual: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,37 +1,11 @@
 spring:
+  # settings for profile
+  profiles:
+    active: prod  # if you want to have the environment of the develop server, then it should be local not dev
+    #include: secret
+  # settings for multipart data such as image
 
-  datasource:
-    url: jdbc:mysql://localhost:3306/indayvidual_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    open-in-view: false
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-        default_batch_fetch_size: 100
-
-  cloud:
-    aws:
-      s3:
-        bucket: ${BUCKET_NAME}
-      region:
-        static: ap-northeast-2
-      stack:
-        auto: false
-      credentials:
-        accessKey: ${AWS_ACCESS_KEY_ID}
-        secretKey: ${AWS_SECRET_ACCESS_KEY}
-
-
-server:
-  port: 8080
-
-logging:
-  level:
-    com.indayvidual: INFO
+  servlet:
+    multipart:
+      max-file-size: 10GB
+      max-request-size: 10GB


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
배포 환경(Elastic Beanstalk)에서 Swagger UI는 정상적으로 열리지만 API 목록이 표시되지 않는 문제를 해결

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #29 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- application.yml에 springdoc.api-docs.enabled=true, springdoc.swagger-ui.enabled=true 명시
- SecurityConfig에서 /v3/api-docs/**, /swagger-ui/** 경로를 permitAll()로 허용

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- application.yml 수정했습니다! application-local.yml을 별도로 만들어야 할것 같습니다. 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 