### PR TITLE
[REFACTOR] JWT 기반 사용자 ID 추출 로직 Utils 클래스로 분리 #39

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import com.indayvidual.server.domain.calendar.service.CalendarQueryService;
+import com.indayvidual.server.global.util.Utils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +37,7 @@ public class CalendarController {
 		@PathVariable int year,
 		@PathVariable int month) {
 
-		Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+		Long userId = Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
 		try {
 			List<GetMonthlyCalendarResponseDto> calendar = calendarQueryService.getMonthlyCalendar(year, month, userId);

--- a/src/main/java/com/indayvidual/server/domain/event/controller/EventController.java
+++ b/src/main/java/com/indayvidual/server/domain/event/controller/EventController.java
@@ -12,6 +12,7 @@ import com.indayvidual.server.domain.event.service.EventQueryService;
 import com.indayvidual.server.global.api.code.status.ErrorStatus;
 import com.indayvidual.server.global.api.code.status.SuccessStatus;
 import com.indayvidual.server.global.api.response.ApiResponse;
+import com.indayvidual.server.global.util.Utils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +36,7 @@ public class EventController {
     public ResponseEntity<ApiResponse<CreateEventResponseDto>> createEvent(
             @Valid @RequestBody CreateEventRequestDto request) {
 
-        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+        Long userId = Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
         try {
             Event createdEvent = eventCommandService.createEvent(request, userId);
@@ -62,7 +63,7 @@ public class EventController {
             @PathVariable Long eventId,
             @Valid @RequestBody UpdateEventRequestDto request) {
 
-        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+        Long userId = Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
         try {
             Event updatedEvent = eventCommandService.updateEvent(eventId, request, userId);
@@ -89,7 +90,7 @@ public class EventController {
     @DeleteMapping("/{eventId}")
     public ResponseEntity<ApiResponse<Void>> deleteEvent(@PathVariable Long eventId) {
 
-        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+        Long userId =  Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
         try {
             eventCommandService.deleteEvent(eventId, userId);
@@ -115,7 +116,7 @@ public class EventController {
     @GetMapping("/{date}")
     public ResponseEntity<ApiResponse<List<GetDayEventResponseDto>>> getDayEvents(@PathVariable String date) {
 
-        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+        Long userId =  Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
         try {
             LocalDate eventDate = LocalDate.parse(date);

--- a/src/main/java/com/indayvidual/server/domain/timetable/controller/TimetableController.java
+++ b/src/main/java/com/indayvidual/server/domain/timetable/controller/TimetableController.java
@@ -10,6 +10,7 @@ import com.indayvidual.server.domain.timetable.service.TimetableQueryService;
 import com.indayvidual.server.global.api.code.status.ErrorStatus;
 import com.indayvidual.server.global.api.code.status.SuccessStatus;
 import com.indayvidual.server.global.api.response.ApiResponse;
+import com.indayvidual.server.global.util.Utils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ public class TimetableController {
     public ResponseEntity<ApiResponse<CreateTimetableResponseDto>> createTimetable(
             @Valid @RequestBody CreateTimetableRequestDto request) {
 
-        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+        Long userId = Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
         try {
             Timetable createdTimetable = timetableCommandService.createTimetable(request, userId);
@@ -65,7 +66,7 @@ public class TimetableController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<GetTimetableResponseDto>>> getTimetables() {
 
-        Long userId = 1L; // TODO: JWT에서 사용자 ID 추출
+        Long userId = Utils.getUserId();; // TODO: JWT에서 사용자 ID 추출
 
         try {
             List<GetTimetableResponseDto> timetables = timetableQueryService.getTimetables(userId);

--- a/src/main/java/com/indayvidual/server/domain/todo/controller/TodoCategoryController.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/controller/TodoCategoryController.java
@@ -5,6 +5,7 @@ import com.indayvidual.server.domain.todo.dto.response.CategoryResponseDTO;
 import com.indayvidual.server.domain.todo.service.category.CategoryCommandService;
 import com.indayvidual.server.domain.todo.service.category.CategoryQueryService;
 import com.indayvidual.server.global.api.response.ApiResponse;
+import com.indayvidual.server.global.util.Utils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,14 +30,14 @@ public class TodoCategoryController {
     @Operation(summary = "카테고리 등록", description = "새로운 카테고리를 등록합니다.")
     @PostMapping("")
     public ApiResponse<CategoryResponseDTO> createCategory(@RequestBody @Valid CategoryCreateRequestDTO request) {
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(categoryCommandService.create(request, userId));
     }
 
     @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
     @GetMapping("")
     public ApiResponse<List<CategoryResponseDTO>> getCategories() {
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(categoryQueryService.findAll(userId));
     }
 }

--- a/src/main/java/com/indayvidual/server/domain/todo/controller/TodoTaskController.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/controller/TodoTaskController.java
@@ -7,6 +7,7 @@ import com.indayvidual.server.domain.todo.dto.response.TaskUpdateResponseDTO;
 import com.indayvidual.server.domain.todo.service.task.TaskCommandService;
 import com.indayvidual.server.domain.todo.service.task.TaskQueryService;
 import com.indayvidual.server.global.api.response.ApiResponse;
+import com.indayvidual.server.global.util.Utils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,7 +45,7 @@ public class TodoTaskController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         // TODO: local date 형식 예외 처리 추가
 
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(taskQueryService.findTasksByCategoryAndDate(userId, categoryId, date));
     }
 
@@ -54,7 +55,7 @@ public class TodoTaskController {
             @PathVariable Long categoryId,
             @RequestBody @Valid TaskCreateRequestDTO request) {
 
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(taskCommandService.createTask(userId, categoryId, request));
     }
 
@@ -64,7 +65,7 @@ public class TodoTaskController {
             @PathVariable Long taskId,
             @RequestBody @Valid TaskTitleUpdateRequestDTO request) {
 
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(taskCommandService.updateTaskTitle(userId, taskId, request));
     }
 
@@ -75,14 +76,14 @@ public class TodoTaskController {
             @RequestBody @Valid TaskDueDateUpdateRequestDTO request) {
         // TODO: local date 형식 예외 처리 추가
 
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(taskCommandService.updateTaskDueDate(userId, taskId, request));
     }
 
     @Operation(summary = "할 일 삭제", description = "할 일을 삭제합니다.")
     @DeleteMapping("/tasks/{taskId}")
     public ApiResponse<Void> deleteTask(@PathVariable Long taskId) {
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         taskCommandService.deleteTask(userId, taskId);
         return ApiResponse.onSuccess(null);
     }
@@ -90,7 +91,7 @@ public class TodoTaskController {
     @Operation(summary = "할 일 체크/체크 해제", description = "할 일을 체크하거나 체크 해제합니다.")
     @PatchMapping("/tasks/{taskId}/check")
     public ApiResponse<TaskCheckUpdateResponseDTO> updateTaskStatus(@PathVariable Long taskId) {
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         return ApiResponse.onSuccess(taskCommandService.toggleCheck(userId, taskId));
     }
 
@@ -106,7 +107,7 @@ public class TodoTaskController {
             @RequestBody @Valid TaskOrderUpdateRequestDTO request) {
 
         //TODO : 카테고리 변경도 추가하기
-        Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+        Long userId = Utils.getUserId();
         taskCommandService.updateTaskOrder(userId, categoryId, request);
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/indayvidual/server/global/util/Utils.java
+++ b/src/main/java/com/indayvidual/server/global/util/Utils.java
@@ -1,5 +1,7 @@
 package com.indayvidual.server.global.util;
 
+import com.indayvidual.server.global.config.security.JwtUserPrincipal;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class Utils {
@@ -18,6 +20,11 @@ public class Utils {
 	}
 
 	public static Long getUserId() {
-		return Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth == null || !(auth.getPrincipal() instanceof JwtUserPrincipal jwt)) {
+			throw new IllegalStateException("인증되지 않은 사용자입니다.");
+		}
+		return jwt.userId();
 	}
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   # settings for profile
   profiles:
-    active: prod  # if you want to have the environment of the develop server, then it should be local not dev
+    active: local  # if you want to have the environment of the develop server, then it should be local not dev
     #include: secret
   # settings for multipart data such as image
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   # settings for profile
   profiles:
-    active: local  # if you want to have the environment of the develop server, then it should be local not dev
+    active: prod  # if you want to have the environment of the develop server, then it should be local not dev
     #include: secret
   # settings for multipart data such as image
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
SpringSecurity에서 Authentication 객체를 JwtAuthenticationToken으로 변경하면서(Principal을 별도의 클래스로 뺐습니다.) 부득이하게 코드 수정을 했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 동규님이 만들어주신 `Utils.getUserId()` 유틸 메서드에서 id를 형변환없이 `JwtUserPrincipal`에서 getId()로 추출하게 바꿨습니다.
- 지수님의 Long userId = Long.parseLong(...getName())` → `Utils.getUserId()`로 교체
- 진경님의 `Long userId = 1L;` 임시 코드 유틸 사용으로 변경

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 