### PR TITLE
[FEAT] 중복 확인, 인증 코드 발송 및 검증 API #42 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 jar {

--- a/src/main/java/com/indayvidual/server/domain/user/controller/EmailVerificationController.java
+++ b/src/main/java/com/indayvidual/server/domain/user/controller/EmailVerificationController.java
@@ -1,0 +1,37 @@
+package com.indayvidual.server.domain.user.controller;
+
+import com.indayvidual.server.domain.user.dto.request.EmailRequestDTO;
+import com.indayvidual.server.domain.user.dto.request.EmailVerifyRequestDTO;
+import com.indayvidual.server.domain.user.service.MailService.EmailVerificationService;
+import com.indayvidual.server.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "이메일 인증 API",
+        description = "이메일 중복 확인, 인증 코드 발송 및 검증 기능을 제공."
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/email")
+public class EmailVerificationController {
+
+    private final EmailVerificationService service;
+
+    @PostMapping("/send")
+    public ResponseEntity<ApiResponse<String>> send(@RequestBody EmailRequestDTO dto) {
+        service.sendVerificationCode(dto.getEmail());
+        return ResponseEntity.ok(ApiResponse.onSuccess("인증번호가 전송되었습니다."));
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<ApiResponse<String>> verify(@RequestBody EmailVerifyRequestDTO dto) {
+        service.verifyCode(dto.getEmail(), dto.getCode());
+        return ResponseEntity.ok(ApiResponse.onSuccess("이메일 인증 성공"));
+    }
+}

--- a/src/main/java/com/indayvidual/server/domain/user/controller/EmailVerificationController.java
+++ b/src/main/java/com/indayvidual/server/domain/user/controller/EmailVerificationController.java
@@ -7,13 +7,10 @@ import com.indayvidual.server.global.api.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(
-        name = "이메일 인증 API",
+        name = "이메일 관련 API",
         description = "이메일 중복 확인, 인증 코드 발송 및 검증 기능을 제공."
 )
 @RestController
@@ -22,6 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class EmailVerificationController {
 
     private final EmailVerificationService service;
+
+    @GetMapping("/check")
+    public ResponseEntity<ApiResponse<Boolean>> checkEmail(@RequestParam String email) {
+        boolean isAvailable = service.isEmailAvailable(email);
+        return ResponseEntity.ok(ApiResponse.onSuccess(isAvailable));
+    }
 
     @PostMapping("/send")
     public ResponseEntity<ApiResponse<String>> send(@RequestBody EmailRequestDTO dto) {

--- a/src/main/java/com/indayvidual/server/domain/user/controller/LocalAuthController.java
+++ b/src/main/java/com/indayvidual/server/domain/user/controller/LocalAuthController.java
@@ -6,6 +6,7 @@ import com.indayvidual.server.domain.user.dto.request.SignupRequestDTO;
 import com.indayvidual.server.domain.user.dto.response.SignupResponseDTO;
 import com.indayvidual.server.domain.user.service.UserService.UserAuthService;
 import com.indayvidual.server.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = " API", description = "이메일 인증 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/indayvidual/server/domain/user/dto/request/EmailRequestDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/user/dto/request/EmailRequestDTO.java
@@ -1,0 +1,12 @@
+package com.indayvidual.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmailRequestDTO {
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+}

--- a/src/main/java/com/indayvidual/server/domain/user/dto/request/EmailVerifyRequestDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/user/dto/request/EmailVerifyRequestDTO.java
@@ -1,0 +1,17 @@
+package com.indayvidual.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class EmailVerifyRequestDTO {
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    @Pattern(regexp = "^[0-9]{4}$", message = "인증번호는 4자리 숫자여야 합니다.")
+    @NotBlank(message = "인증번호는 필수입니다.")
+    private String code;
+}

--- a/src/main/java/com/indayvidual/server/domain/user/entity/EmailVerification.java
+++ b/src/main/java/com/indayvidual/server/domain/user/entity/EmailVerification.java
@@ -1,0 +1,42 @@
+package com.indayvidual.server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+        @Index(columnList = "email"),
+        @Index(columnList = "expiredAt")
+})
+public class EmailVerification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String code;
+
+    private LocalDateTime expiredAt;
+    private boolean verified;
+
+    public static EmailVerification create(String email, String code, Duration ttl) {
+        EmailVerification ev = new EmailVerification();
+        ev.email = email;
+        ev.code = code;
+        ev.expiredAt = LocalDateTime.now().plus(ttl);
+        ev.verified = false;
+        return ev;
+    }
+
+    public boolean isExpired() { return LocalDateTime.now().isAfter(expiredAt); }
+    public void markVerified() { this.verified = true; }
+}
+

--- a/src/main/java/com/indayvidual/server/domain/user/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/user/repository/EmailVerificationRepository.java
@@ -1,0 +1,20 @@
+package com.indayvidual.server.domain.user.repository;
+
+import com.indayvidual.server.domain.user.entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailVerificationRepository
+        extends JpaRepository<EmailVerification, Long> {
+
+    /** 최신 발송건 조회 (재전송 제한 등 필요 시) */
+    Optional<EmailVerification> findTopByEmailOrderByIdDesc(String email);
+
+    /** 검증용 */
+    Optional<EmailVerification> findByEmailAndCode(String email, String code);
+
+    /** 만료 코드 일괄 삭제 */
+    void deleteByExpiredAtBefore(LocalDateTime dateTime);
+}

--- a/src/main/java/com/indayvidual/server/domain/user/service/MailService/EmailVerificationService.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/MailService/EmailVerificationService.java
@@ -1,0 +1,62 @@
+package com.indayvidual.server.domain.user.service.MailService;
+
+import com.indayvidual.server.domain.user.entity.EmailVerification;
+import com.indayvidual.server.domain.user.repository.EmailVerificationRepository;
+import com.indayvidual.server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EmailVerificationService {
+
+    private static final Duration EXPIRE = Duration.ofMinutes(10);
+    private static final int CODE_LENGTH = 4;
+
+    private final EmailVerificationRepository repo;
+    private final UserRepository userRepository;
+    private final MailService mailService;
+
+    public void sendVerificationCode(String email) {
+
+        // 새 코드 생성
+        String code = generateCode();
+        repo.save(EmailVerification.create(email, code, EXPIRE));
+
+        // 메일 전송
+        String subject = "[Indayvidual] 이메일 인증번호 안내";
+        String body = String.format("""
+                안녕하세요!
+                
+                요청하신 인증번호는 %s 입니다.
+                %d분 내에 입력해 주세요.
+                
+                감사합니다.
+                """, code, EXPIRE.toMinutes());
+
+        mailService.sendSimpleMessage(email, subject, body);
+    }
+
+    // 사용자가 입력한 인증번호 검증
+    public void verifyCode(String email, String code) {
+        EmailVerification ev = repo.findByEmailAndCode(email, code)
+                .orElseThrow(() -> new IllegalArgumentException("인증번호가 일치하지 않습니다."));
+
+        if (ev.isExpired()) {
+            throw new IllegalStateException("인증번호가 만료되었습니다.");
+        }
+        ev.markVerified(); // verified = true
+    }
+
+    //util: n자리 숫자 난수
+    private String generateCode() {
+        int bound = (int) Math.pow(10, EmailVerificationService.CODE_LENGTH);
+        return String.format("%0" + EmailVerificationService.CODE_LENGTH + "d", ThreadLocalRandom.current().nextInt(bound));
+    }
+}
+

--- a/src/main/java/com/indayvidual/server/domain/user/service/MailService/EmailVerificationService.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/MailService/EmailVerificationService.java
@@ -22,8 +22,12 @@ public class EmailVerificationService {
     private final UserRepository userRepository;
     private final MailService mailService;
 
-    public void sendVerificationCode(String email) {
+    @Transactional(readOnly = true)
+    public boolean isEmailAvailable(String email) {
+        return !userRepository.existsByEmail(email);
+    }
 
+    public void sendVerificationCode(String email) {
         // 새 코드 생성
         String code = generateCode();
         repo.save(EmailVerification.create(email, code, EXPIRE));

--- a/src/main/java/com/indayvidual/server/domain/user/service/MailService/MailService.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/MailService/MailService.java
@@ -1,0 +1,29 @@
+package com.indayvidual.server.domain.user.service.MailService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender mailSender;
+    @Value("${spring.mail.username}") // Gmail 계정 주소
+    private String from;
+
+
+    /** 단순 텍스트 메일 */
+    public void sendSimpleMessage(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+
+    // HTML 템플릿/FreeMarker/Thymeleaf 등으로 확장 가능
+}

--- a/src/main/java/com/indayvidual/server/global/scheduler/EmailVerificationCleaner.java
+++ b/src/main/java/com/indayvidual/server/global/scheduler/EmailVerificationCleaner.java
@@ -1,0 +1,21 @@
+package com.indayvidual.server.global.scheduler;
+
+import com.indayvidual.server.domain.user.repository.EmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationCleaner {
+
+    private final EmailVerificationRepository repo;
+
+    /** “0 0 12 * * ?”  → 매일 12:00 PM KST */
+    @Scheduled(cron = "0 0 12 * * ?")
+    public void clean() {
+        repo.deleteByExpiredAtBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,6 +23,19 @@ spring:
         format_sql: true
         show_sql: true
         default_batch_fetch_size: 100
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+      mail.smtp.connectiontimeout: 5000
+      mail.smtp.timeout: 5000
+      mail.smtp.writetimeout: 5000
+
   #aws
   cloud:
     aws:


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
사용자 이메일의 유효성 검증과 인증 코드를 통한 이메일 인증을 처리

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #42 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 이메일 인증을 위한 EmailVerification 엔티티 추가
- 인증 코드 전송,검증 API
- JavaMailSender를 활용한 SMTP 기반 메일 전송 기능 구현
- 매일 정오에 만료된 인증 레코드 정리하는 스케줄러 추가
- 이메일 사용 가능 여부를 확인하는 GET API 추가

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 환경변수 추가된 값이 있습니다. 카톡으로 알려드리겠습니다. 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 