### PR TITLE
[FEAT] Refresh Token 기반 로그인/로그아웃 및 토큰 재발급 기능 구현 #44

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/indayvidual/server/domain/user/controller/AuthController.java
@@ -4,26 +4,27 @@ import com.indayvidual.server.domain.user.dto.request.LoginRequestDTO;
 import com.indayvidual.server.domain.user.dto.response.LoginResponseDTO;
 import com.indayvidual.server.domain.user.dto.request.SignupRequestDTO;
 import com.indayvidual.server.domain.user.dto.response.SignupResponseDTO;
+import com.indayvidual.server.domain.user.service.UserService.RefreshTokenService;
 import com.indayvidual.server.domain.user.service.UserService.UserAuthService;
 import com.indayvidual.server.global.api.response.ApiResponse;
+import com.indayvidual.server.global.config.security.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@Tag(name = " API", description = "이메일 인증 관련 API")
+@Tag(name = "Auth API", description = "회원가입, 로그인 기능 제공")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
-public class LocalAuthController {
+public class AuthController {
 
     private final UserAuthService userAuthService;
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponseDTO>> signup(@RequestBody SignupRequestDTO request) {
@@ -39,21 +40,24 @@ public class LocalAuthController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<String>> logout(HttpServletRequest request) {
-        // 서버에서는 토큰 삭제 대신, 이후 요청 차단을 위한 로그 또는 blacklist 처리 가능
-        String token = extractToken(request);
-        log.info("사용자 로그아웃 요청: {}", token);
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(
+            @RequestHeader("Refresh-Token") String refreshToken
+    ) {
+        if (refreshToken.startsWith("Bearer ")) {
+            refreshToken = refreshToken.substring(7);
+        }
+        LoginResponseDTO dto = refreshTokenService.rotate(refreshToken);
+        return ResponseEntity.ok(ApiResponse.onSuccess(dto));
+    }
 
-        // TODO: Redis에 token blacklist 등록, DB에 refresh token 제거 등 추가 가능
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(
+            @RequestHeader("Authorization") String bearerToken
+    ) {
+        String refreshToken = bearerToken.replace("Bearer ", "");
+        userAuthService.logoutWithRefreshToken(refreshToken);
         return ResponseEntity.ok(ApiResponse.onSuccess("로그아웃 완료"));
     }
 
-    private String extractToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (bearer != null && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/indayvidual/server/domain/user/controller/EmailVerificationController.java
+++ b/src/main/java/com/indayvidual/server/domain/user/controller/EmailVerificationController.java
@@ -10,8 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(
-        name = "이메일 관련 API",
-        description = "이메일 중복 확인, 인증 코드 발송 및 검증 기능을 제공."
+        name = "Email API",
+        description = "이메일 중복 확인, 인증 코드 발송 및 검증 기능을 제공"
 )
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/indayvidual/server/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/indayvidual/server/domain/user/entity/RefreshToken.java
@@ -1,0 +1,60 @@
+package com.indayvidual.server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(indexes = @Index(columnList = "tokenId"))
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private String tokenId;
+    private String hashedToken;
+    private LocalDateTime expiredAt;
+    private boolean revoked = false;
+
+    public static RefreshToken of(Long userId,
+                                  String tokenId,
+                                  String rawToken,
+                                  Duration ttl) {
+        return new RefreshToken(
+                null,
+                userId,
+                tokenId,
+                hash(rawToken),
+                LocalDateTime.now().plus(ttl),
+                false
+        );
+    }
+
+    // 토큰 일치 여부 (만료시간 + revoked 상태 체크)
+    public boolean match(String rawToken) {
+        return !revoked
+                && !isExpired()
+                && Objects.equals(this.hashedToken, hash(rawToken));
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiredAt);
+    }
+
+    public void revoke() {
+        this.revoked = true;
+    }
+
+    private static String hash(String token) {
+        return DigestUtils.sha256Hex(token);
+    }
+}

--- a/src/main/java/com/indayvidual/server/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.indayvidual.server.domain.user.repository;
+
+import com.indayvidual.server.domain.user.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByTokenId(String tokenId);
+    void deleteByExpiredAtBefore(LocalDateTime time);
+}
+

--- a/src/main/java/com/indayvidual/server/domain/user/service/UserService/RefreshTokenService.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/UserService/RefreshTokenService.java
@@ -1,0 +1,76 @@
+package com.indayvidual.server.domain.user.service.UserService;
+
+import com.indayvidual.server.domain.user.dto.response.LoginResponseDTO;
+import com.indayvidual.server.domain.user.entity.RefreshToken;
+import com.indayvidual.server.domain.user.entity.User;
+import com.indayvidual.server.domain.user.repository.RefreshTokenRepository;
+import com.indayvidual.server.domain.user.repository.UserRepository;
+import com.indayvidual.server.global.config.security.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository repo;
+    private final JwtTokenProvider jwt;
+    private final UserRepository userRepo;
+
+    /** 로그인 시 호출 → 서버에 RefreshToken 저장 */
+    public String saveRefreshToken(User user) {
+        String refresh = jwt.generateRefreshToken(user);
+        Claims claims = jwt.parseClaims(refresh); // jti, exp …
+
+        repo.save(RefreshToken.of(
+                user.getId(),
+                claims.getId(),
+                refresh,
+                Duration.between(Instant.now(), claims.getExpiration().toInstant())
+        ));
+        return refresh;
+    }
+
+    /** /api/auth/refresh 호출 */
+    public LoginResponseDTO rotate(String oldRefresh) {
+        Claims claims = jwt.parseClaims(oldRefresh);
+        log.info("claims.getId() = {}", claims.getId());
+        log.info("claims = {}", claims);  // 전체 claims 로그
+        log.info("추출된 tokenId(jti): {}", claims.getId());
+        RefreshToken stored = repo.findByTokenId(claims.getId())
+                .orElseThrow(() -> new IllegalStateException("유효하지 않은 refreshToken"));
+
+        if (!stored.match(oldRefresh) || stored.isRevoked() || stored.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalStateException("만료되었거나 취소된 refreshToken");
+        }
+
+        // 1) 현재 refreshToken 사용 종료
+        stored.revoke();
+
+        // 2) 새 토큰 발급
+        User user = userRepo.findById(Long.parseLong(claims.getSubject()))
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 유저"));
+
+        String newAccess = jwt.generateAccessToken(user);
+        String newRefresh = saveRefreshToken(user); // 위 메서드 재사용
+
+        return LoginResponseDTO.builder()
+                .accessToken(newAccess)
+                .refreshToken(newRefresh)
+                .userId(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .role(user.getRole().name())
+                .build();
+    }
+}
+

--- a/src/main/java/com/indayvidual/server/domain/user/service/UserService/UserAuthService.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/UserService/UserAuthService.java
@@ -7,4 +7,5 @@ import com.indayvidual.server.domain.user.dto.response.SignupResponseDTO;
 public interface UserAuthService {
     SignupResponseDTO signupWithEmail(SignupRequestDTO request);
     LoginResponseDTO loginWithEmailAndPassword(String email, String password);
+    void logoutWithRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/indayvidual/server/domain/user/service/UserService/UserAuthServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/UserService/UserAuthServiceImpl.java
@@ -3,21 +3,27 @@ package com.indayvidual.server.domain.user.service.UserService;
 import com.indayvidual.server.domain.user.dto.response.LoginResponseDTO;
 import com.indayvidual.server.domain.user.dto.request.SignupRequestDTO;
 import com.indayvidual.server.domain.user.dto.response.SignupResponseDTO;
+import com.indayvidual.server.domain.user.entity.RefreshToken;
 import com.indayvidual.server.domain.user.entity.User;
 import com.indayvidual.server.domain.user.entity.UserProvider;
 import com.indayvidual.server.domain.user.entity.enums.Provider;
 import com.indayvidual.server.domain.user.entity.enums.Role;
 import com.indayvidual.server.domain.user.entity.enums.Status;
+import com.indayvidual.server.domain.user.repository.RefreshTokenRepository;
 import com.indayvidual.server.domain.user.repository.UserProviderRepository;
 import com.indayvidual.server.domain.user.repository.UserRepository;
 import com.indayvidual.server.global.config.security.JwtTokenProvider;
+import com.indayvidual.server.global.config.security.JwtValidationType;
 import com.indayvidual.server.global.config.security.UserAuthentication;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -27,6 +33,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     private final UserRepository userRepository;
     private final UserProviderRepository userProviderRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -97,6 +104,14 @@ public class UserAuthServiceImpl implements UserAuthService {
         String accessToken = jwtTokenProvider.generateAccessToken(user);
         String refreshToken = jwtTokenProvider.generateRefreshToken(user);
 
+        Claims claims = jwtTokenProvider.parseClaims(refreshToken);
+        refreshTokenRepository.save(RefreshToken.of(
+                user.getId(),
+                claims.getId(),
+                refreshToken,
+                Duration.between(Instant.now(), claims.getExpiration().toInstant())
+        ));
+
         return LoginResponseDTO.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -105,5 +120,12 @@ public class UserAuthServiceImpl implements UserAuthService {
                 .username(user.getUsername())
                 .role(user.getRole().name())
                 .build();
+    }
+
+    @Override
+    public void logoutWithRefreshToken(String refreshToken) {
+        Claims claims = jwtTokenProvider.parseClaims(refreshToken);
+        refreshTokenRepository.findByTokenId(claims.getId())
+                .ifPresent(RefreshToken::revoke);
     }
 }

--- a/src/main/java/com/indayvidual/server/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/indayvidual/server/global/config/security/JwtAuthenticationFilter.java
@@ -1,11 +1,9 @@
 package com.indayvidual.server.global.config.security;
 
-import static com.indayvidual.server.global.config.security.JwtValidationType.*;
-
 import java.io.IOException;
 
+import io.jsonwebtoken.Claims;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,16 +16,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.List;
-
-import static com.indayvidual.server.global.config.security.JwtValidationType.VALID_JWT;
 
 @Slf4j
 @Component
@@ -45,6 +33,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = getJwtFromRequest(request);
 
             if (token != null && jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
+                Claims claims = jwtTokenProvider.parseClaims(token);
+
+                if (!"access".equals(claims.get("tokenType"))) {
+                    throw new IllegalArgumentException("Access Token이 아닙니다.");
+                }
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/com/indayvidual/server/global/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/indayvidual/server/global/config/security/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.indayvidual.server.domain.user.entity.*;
 import com.indayvidual.server.domain.user.entity.enums.Role;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.micrometer.common.lang.Nullable;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -27,8 +29,12 @@ public class JwtTokenProvider {
 
     private static final String USER_ID = "userId";
     private static final String ROLE = "role";
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L; // 24시간
-    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
+    private static final String TOKEN_TYPE = "tokenType";
+    private static final String TOKEN_TYPE_ACCESS = "access";
+    private static final String TOKEN_TYPE_REFRESH = "refresh";
+
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000L;  // 15분
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * 1000L; // 14일
 
     @Value("${auth.jwt.secret}")
     private String jwtSecret;
@@ -49,56 +55,39 @@ public class JwtTokenProvider {
     }
 
     public String generateAccessToken(User user) {
-        return generateToken(user, ACCESS_TOKEN_EXPIRATION_TIME);
+        return generateToken(user, ACCESS_TOKEN_EXPIRATION_TIME, TOKEN_TYPE_ACCESS, null);
     }
 
     public String generateRefreshToken(User user) {
-        return generateToken(user, REFRESH_TOKEN_EXPIRATION_TIME);
+        String tokenId = UUID.randomUUID().toString();   // ★ jti
+        return generateToken(user, REFRESH_TOKEN_EXPIRATION_TIME, TOKEN_TYPE_REFRESH, tokenId);
     }
 
-    // 로그인 시점 (User 엔티티)
-    private String generateToken(User user, Long expirationTime) {
-        final Date now = new Date();
-        final Date expiryDate = new Date(now.getTime() + expirationTime);
+    // 공통 로직
+    private String generateToken(User user,
+                                 long expirationTime,
+                                 String tokenType,
+                                 @Nullable String jti) {
 
-        return Jwts.builder()
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expirationTime);
+
+        JwtBuilder builder = Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setSubject(user.getId().toString())
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .claim(USER_ID, user.getId())
                 .claim(ROLE, user.getRole().name())
-                .signWith(signingKey)
-                .compact();
-    }
+                .claim(TOKEN_TYPE, tokenType)     // ★ access / refresh
+                .signWith(signingKey);
 
-    // 이미 인증된 상태에서 토큰 재발급(Authentication)
-    public String generateTokenFromAuthentication(Authentication authentication) {
-        if (authentication.getPrincipal() instanceof JwtUserPrincipal) {
-            JwtUserPrincipal principal = (JwtUserPrincipal) authentication.getPrincipal();
-            return generateTokenFromPrincipal(principal, ACCESS_TOKEN_EXPIRATION_TIME);
-        } else if (authentication.getPrincipal() instanceof Long) {
-            // 현재 구조 호환성을 위해 추가
-            Long userId = (Long) authentication.getPrincipal();
-            // 실제로는 DB에서 사용자 정보를 조회해야 함
-            throw new IllegalArgumentException("Cannot generate token from Long principal. Use User entity instead.");
-        }
-        throw new IllegalArgumentException("Unsupported principal type");
-    }
+        if (jti != null) {
+            builder.setId(jti);
+            log.info("jti 추가됨: {}", jti);
+        }        // ★ refresh 전용
 
-    private String generateTokenFromPrincipal(JwtUserPrincipal principal, Long expirationTime) {
-        final Date now = new Date();
-        final Date expiryDate = new Date(now.getTime() + expirationTime);
-
-        return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject(principal.userId().toString())
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .claim(USER_ID, principal.userId())
-                .claim(ROLE, principal.role().name())
-                .signWith(signingKey)
-                .compact();
+        return builder.compact();
     }
 
     // 토큰으로부터 Authentication 객체 생성
@@ -118,15 +107,10 @@ public class JwtTokenProvider {
 
     // 토큰 검증
     public JwtValidationType validateToken(String token) {
-        if (!StringUtils.hasText(token)) {
-            return JwtValidationType.EMPTY_JWT;
-        }
+        if (!StringUtils.hasText(token)) return JwtValidationType.EMPTY_JWT;
 
         try {
-            Jwts.parserBuilder()
-                    .setSigningKey(signingKey)
-                    .build()
-                    .parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token);
             return JwtValidationType.VALID_JWT;
         } catch (ExpiredJwtException ex) {
             log.warn("JWT token expired");
@@ -137,11 +121,8 @@ public class JwtTokenProvider {
         } catch (MalformedJwtException ex) {
             log.warn("Invalid JWT token");
             return JwtValidationType.INVALID_JWT_TOKEN;
-        } catch (IllegalArgumentException ex) {
-            log.warn("JWT token compact of handler are invalid");
-            return JwtValidationType.EMPTY_JWT;
         } catch (Exception ex) {
-            log.error("JWT token validation failed", ex);
+            log.error("JWT validation failed", ex);
             return JwtValidationType.INVALID_JWT_TOKEN;
         }
     }
@@ -162,6 +143,26 @@ public class JwtTokenProvider {
         } catch (JwtException ex) {
             throw new IllegalArgumentException("Invalid JWT token", ex);
         }
+    }
+
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(signingKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims(); // 만료되었어도 Claims는 추출 가능
+        } catch (JwtException | IllegalArgumentException e) {
+            // 구조가 잘못됐거나 서명 오류, null 등
+            log.warn("JWT 파싱 실패: {}", e.getMessage());
+            throw new IllegalArgumentException("유효하지 않은 JWT 토큰입니다.", e);
+        }
+    }
+
+    public boolean isRefreshToken(String token) {
+        return TOKEN_TYPE_REFRESH.equals(getBody(token).get(TOKEN_TYPE, String.class));
     }
 
     private Claims getBody(String token) {

--- a/src/main/java/com/indayvidual/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/indayvidual/server/global/config/security/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/**",
+            "/api/auth/refresh",
             "/api/auth/login/**",
             "/auth/kakao/login/**",
             "/temp/health"

--- a/src/main/java/com/indayvidual/server/global/scheduler/RefreshTokenCleaner.java
+++ b/src/main/java/com/indayvidual/server/global/scheduler/RefreshTokenCleaner.java
@@ -1,0 +1,20 @@
+package com.indayvidual.server.global.scheduler;
+
+import com.indayvidual.server.domain.user.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleaner {
+
+    private final RefreshTokenRepository repo;
+
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 03:00
+    public void clean() {
+        repo.deleteByExpiredAtBefore(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Refresh Token 기반 로그인/로그아웃 및 토큰 재발급 기능 구현

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #44 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- JwtTokenProvider에 jti(UUID) 기반 refreshToken 발급 로직 추가
- tokenType(access/refresh) 토큰 종류 구분 가능하도록 수정
- RefreshToken 엔티티 및 Repository 구현 (서버에 refreshToken 저장)
- RefreshTokenService 구현: 저장, 검증, 회전, 폐기 로직 포함
- access/refresh 토큰 재발급 기능
- refreshToken 기반 로그아웃 API 구현

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 완전히 로그아웃하려면 accessToken을 blacklist에 추가하는 로직도 있는데 그거는 추후에..

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 