### PR TITLE
Feat/#52 event api update

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/controller/CalendarController.java
@@ -32,7 +32,7 @@ public class CalendarController {
 
 	private final CalendarQueryService calendarQueryService;
 
-	@GetMapping("/{year}/{month}")
+	@GetMapping("/home/{year}/{month}")
 	public ResponseEntity<ApiResponse<List<GetMonthlyCalendarResponseDto>>> getMonthlyCalendar(
 		@PathVariable int year,
 		@PathVariable int month) {

--- a/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetMonthlyCalendarResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetMonthlyCalendarResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,7 +18,5 @@ public class GetMonthlyCalendarResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    private Boolean hasEvent;
-
-    private Boolean hasTodo;
+    private List<String> colors;
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/service/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/service/CalendarQueryServiceImpl.java
@@ -1,8 +1,6 @@
 package com.indayvidual.server.domain.calendar.service;
 
-import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.calendar.dto.response.GetMonthlyCalendarResponseDto;
-import com.indayvidual.server.domain.event.converter.EventConverter;
 import com.indayvidual.server.domain.event.entity.Event;
 import com.indayvidual.server.domain.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,23 +25,28 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
         LocalDate startDate = yearMonth.atDay(1);
         LocalDate endDate = yearMonth.atEndOfMonth();
 
-        List<LocalDate> eventDates = eventRepository.findEventDatesByUserIdAndDateRange(userId, startDate, endDate);
-        Set<LocalDate> eventDateSet = eventDates.stream().collect(Collectors.toSet());
+        List<Event> events = eventRepository.findByUserIdAndEventDateBetween(userId, startDate, endDate);
 
-        // TODO: 할일 기능 구현 후 할일 날짜 조회
-        // Set<LocalDate> todoDataSet = todoRepository.findTodoDatesByUserIdAndDateRange(userId, startDate, endDate);
+        Map<LocalDate, List<String>> dateColorsMap = events.stream()
+                .collect(Collectors.groupingBy(
+                        Event::getEventDate,
+                        LinkedHashMap::new,
+                        Collectors.mapping(Event::getColorCode, Collectors.toList())
+                ));
 
         List<GetMonthlyCalendarResponseDto> result = new ArrayList<>();
         LocalDate currentDate = startDate;
 
         while (!currentDate.isAfter(endDate)) {
+            List<String> colors = dateColorsMap.getOrDefault(currentDate, Collections.emptyList());
+
             result.add(GetMonthlyCalendarResponseDto.builder()
                     .date(currentDate)
-                    .hasEvent(eventDateSet.contains(currentDate))
-                    .hasTodo(false) // TODO: 할일 기능 구현 후 수정 - todoDateSet.contains(currentDate)
+                    .colors(colors)
                     .build());
             currentDate = currentDate.plusDays(1);
         }
+
         return result;
     }
 }

--- a/src/main/java/com/indayvidual/server/domain/event/controller/EventController.java
+++ b/src/main/java/com/indayvidual/server/domain/event/controller/EventController.java
@@ -29,7 +29,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/events")
 @RequiredArgsConstructor
-@Tag(name = "Event", description = "이벤트 관리 API")
+@Tag(name = "Event", description = "일정 관리 API")
 public class EventController {
 
     private final EventCommandService eventCommandService;
@@ -37,9 +37,9 @@ public class EventController {
     private final EventConverter eventConverter;
 
     @PostMapping
-    @Operation(summary = "이벤트 생성", description = "새로운 이벤트를 생성합니다.")
+    @Operation(summary = "일정 생성", description = "새로운 일정을 생성합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이벤트 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정 생성 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })
@@ -58,15 +58,15 @@ public class EventController {
     }
 
     @PatchMapping("/{eventId}")
-    @Operation(summary = "이벤트 수정", description = "기존 이벤트를 수정합니다.")
+    @Operation(summary = "일정 수정", description = "기존 일정을 수정합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이벤트 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정 수정 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "일정을 찾을 수 없음")
     })
     public ApiResponse<UpdateEventResponseDto> updateEvent(
-            @Parameter(description = "이벤트 ID", required = true) @PathVariable Long eventId,
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long eventId,
             @Valid @RequestBody UpdateEventRequestDto request) {
 
         Long userId = Utils.getUserId();
@@ -81,14 +81,14 @@ public class EventController {
     }
 
     @DeleteMapping("/{eventId}")
-    @Operation(summary = "이벤트 삭제", description = "이벤트를 삭제합니다.")
+    @Operation(summary = "일정 삭제", description = "일정을 삭제합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이벤트 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정 삭제 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "일정을 찾을 수 없음")
     })
     public ApiResponse<Void> deleteEvent(
-            @Parameter(description = "이벤트 ID", required = true) @PathVariable Long eventId) {
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long eventId) {
 
         Long userId = Utils.getUserId();
         eventCommandService.deleteEvent(eventId, userId);
@@ -101,9 +101,9 @@ public class EventController {
     }
 
     @GetMapping("/{date}")
-    @Operation(summary = "특정 날짜 이벤트 조회", description = "특정 날짜의 모든 이벤트를 조회합니다.")
+    @Operation(summary = "특정 날짜 일정 조회", description = "특정 날짜의 모든 일정을 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이벤트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 날짜 형식"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
     })

--- a/src/main/java/com/indayvidual/server/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/indayvidual/server/domain/event/converter/EventConverter.java
@@ -38,6 +38,7 @@ public class EventConverter {
     public UpdateEventResponseDto toUpdateResponse(Event entity) {
         return UpdateEventResponseDto.builder()
                 .eventId(entity.getId())
+                .date(entity.getEventDate())
                 .title(entity.getTitle())
                 .startTime(entity.getStartTime())
                 .endTime(entity.getEndTime())
@@ -46,6 +47,9 @@ public class EventConverter {
     }
 
     public void updateEntityFromRequest(Event entity, UpdateEventRequestDto request) {
+        if (request.getDate() != null) {
+            entity.setEventDate(request.getDate());
+        }
         if (StringUtils.hasText(request.getTitle())) {
             entity.setTitle(request.getTitle().trim());
         }

--- a/src/main/java/com/indayvidual/server/domain/event/dto/request/CreateEventRequestDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/request/CreateEventRequestDto.java
@@ -16,15 +16,15 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "이벤트 생성 요청 DTO")
+@Schema(description = "일정 생성 요청 DTO")
 public class CreateEventRequestDto {
 
-    @Schema(description = "이벤트 날짜", example = "2025-07-22", required = true)
+    @Schema(description = "일정 날짜", example = "2025-07-22", required = true)
     @NotNull(message = "날짜는 필수입니다.")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    @Schema(description = "이벤트 제목", example = "회의", required = true)
+    @Schema(description = "일정 제목", example = "회의", required = true)
     @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 20, message = "제목은 20자 이내여야 합니다.")
     private String title;

--- a/src/main/java/com/indayvidual/server/domain/event/dto/request/UpdateEventRequestDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/request/UpdateEventRequestDto.java
@@ -15,14 +15,14 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "이벤트 수정 요청 DTO")
+@Schema(description = "일정 수정 요청 DTO")
 public class UpdateEventRequestDto {
 
-    @Schema(description = "이벤트 날짜", example = "2025-07-22")
+    @Schema(description = "일정 날짜", example = "2025-07-22")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    @Schema(description = "이벤트 제목", example = "회의")
+    @Schema(description = "일정 제목", example = "회의")
     @Size(max = 20, message = "제목은 20자 이내여야 합니다.")
     private String title;
 

--- a/src/main/java/com/indayvidual/server/domain/event/dto/request/UpdateEventRequestDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/request/UpdateEventRequestDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
@@ -16,6 +17,10 @@ import java.time.LocalTime;
 @Builder
 @Schema(description = "이벤트 수정 요청 DTO")
 public class UpdateEventRequestDto {
+
+    @Schema(description = "이벤트 날짜", example = "2025-07-22")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
 
     @Schema(description = "이벤트 제목", example = "회의")
     @Size(max = 20, message = "제목은 20자 이내여야 합니다.")

--- a/src/main/java/com/indayvidual/server/domain/event/dto/response/CreateEventResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/response/CreateEventResponseDto.java
@@ -8,9 +8,9 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "이벤트 생성 응답 DTO")
+@Schema(description = "일정 생성 응답 DTO")
 public class CreateEventResponseDto {
 
-    @Schema(description = "생성된 이벤트 ID", example = "1")
+    @Schema(description = "생성된 일정 ID", example = "1")
     private Long eventId;
 }

--- a/src/main/java/com/indayvidual/server/domain/event/dto/response/UpdateEventResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/response/UpdateEventResponseDto.java
@@ -12,17 +12,17 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "이벤트 수정 응답 DTO")
+@Schema(description = "일정 수정 응답 DTO")
 public class UpdateEventResponseDto {
 
     @Schema(description = "일정 날짜", example = "2025-07-22")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    @Schema(description = "이벤트 ID", example = "1")
+    @Schema(description = "일정 ID", example = "1")
     private Long eventId;
 
-    @Schema(description = "이벤트 제목", example = "회의")
+    @Schema(description = "일정 제목", example = "회의")
     private String title;
 
     @Schema(description = "시작 시간", example = "10:00")

--- a/src/main/java/com/indayvidual/server/domain/event/dto/response/UpdateEventResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/response/UpdateEventResponseDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
@@ -13,6 +14,10 @@ import java.time.LocalTime;
 @Builder
 @Schema(description = "이벤트 수정 응답 DTO")
 public class UpdateEventResponseDto {
+
+    @Schema(description = "일정 날짜", example = "2025-07-22")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
 
     @Schema(description = "이벤트 ID", example = "1")
     private Long eventId;

--- a/src/main/java/com/indayvidual/server/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/event/repository/EventRepository.java
@@ -14,27 +14,27 @@ import java.util.Optional;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     /**
-     * 사용자 ID와 이벤트 ID로 이벤트 조회
+     * 사용자 ID와 일정 ID로 일정 조회
      */
     Optional<Event> findByIdAndUserId(Long id, Long userId);
 
     /**
-     * 사용자 ID와 이벤트 ID로 이벤트 삭제
+     * 사용자 ID와 일정 ID로 일정 삭제
      */
     void deleteByIdAndUserId(Long id, Long userId);
 
     /**
-     * 사용자 ID와 이벤트 ID로 이벤트 존재 여부 확인
+     * 사용자 ID와 일정 ID로 일정 존재 여부 확인
      */
     boolean existsByIdAndUserId(Long id, Long userId);
 
     /**
-     * 특정 날짜의 사용자 이벤트를 시작 시간 순으로 조회
+     * 특정 날짜의 사용자 일정을 시작 시간 순으로 조회
      */
     List<Event> findByUserIdAndEventDateOrderByStartTimeAsc(Long userId, LocalDate eventDate);
 
     /**
-     * 사용자 ID와 낢짜 범위로 일정(Event) 전체 조회
+     * 사용자 ID와 낢짜 범위로 일정 전체 조회
      */
     List<Event> findByUserIdAndEventDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/indayvidual/server/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/event/repository/EventRepository.java
@@ -29,17 +29,12 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     boolean existsByIdAndUserId(Long id, Long userId);
 
     /**
-     * 사용자 ID와 날짜 범위로 이벤트 날짜 조회\
-     */
-    @Query("SELECT DISTINCT e.eventDate FROM Event e " +
-            "WHERE e.userId = :userId AND e.eventDate BETWEEN :startDate AND :endDate")
-    List<LocalDate> findEventDatesByUserIdAndDateRange(
-            @Param("userId") Long userId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
-
-    /**
      * 특정 날짜의 사용자 이벤트를 시작 시간 순으로 조회
      */
     List<Event> findByUserIdAndEventDateOrderByStartTimeAsc(Long userId, LocalDate eventDate);
+
+    /**
+     * 사용자 ID와 낢짜 범위로 일정(Event) 전체 조회
+     */
+    List<Event> findByUserIdAndEventDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
일정 관련 API를 수정했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #52 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 홈-월별 캘린더 조회
   - 투두-캘린더 조회 API는 필요가 없다고 생각하여 구현하지 않았습니다 (캘린더 상 미리보기로 표시되는 부분이 없기 때문에)
   - 홈 탭에서 캘린더 조회 시 일정의 색상이 각 날짜별로 보이기 때문에 월별 캘린더 조회 시 기존의 일정과 할일의 유무를 반환하는 방식에서 일정의 color를 반환하도록 수정 했습니다.
- 일정 수정 시 날짜도 변경이 가능하도록 수정했습니다.

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 