### PR TITLE
:sparkles: [FEAT] 메모 수정 기능 추가 및 제목 필드 제거

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -1,9 +1,6 @@
 name: Indayvidual Develop CI/CD
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     types: [ closed ]
   workflow_dispatch: # (2).수동 실행도 가능하도록
@@ -11,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest # (3). OS환경
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
 
     steps:
       - name: Checkout

--- a/src/main/java/com/indayvidual/server/domain/memo/controller/MemoController.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/controller/MemoController.java
@@ -2,6 +2,7 @@ package com.indayvidual.server.domain.memo.controller;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.indayvidual.server.domain.memo.dto.request.CreateMemoRequestDTO;
+import com.indayvidual.server.domain.memo.dto.request.UpdateMemoRequestDTO;
 import com.indayvidual.server.domain.memo.dto.response.MemoDetailResponseDTO;
 import com.indayvidual.server.domain.memo.dto.response.MemoSliceResponseDTO;
 import com.indayvidual.server.domain.memo.service.command.MemoCommandService;
@@ -104,6 +106,17 @@ public class MemoController {
 	) {
 		Long userId = Utils.getUserId();
 		return ApiResponse.onSuccess(memoQueryService.getMemoDetail(userId, memoId));
+	}
+
+	@PatchMapping("/{memoId}")
+	public ApiResponse<MemoDetailResponseDTO> updateMemo(
+		@Parameter(description = "메모 ID", required = true, example = "1")
+		@PathVariable Long memoId,
+
+		@RequestBody @Valid UpdateMemoRequestDTO request
+	) {
+		Long userId = Utils.getUserId();
+		return ApiResponse.onSuccess(memoCommandService.updateMemo(userId, memoId, request));
 	}
 
 	@DeleteMapping("/{memoId}")

--- a/src/main/java/com/indayvidual/server/domain/memo/dto/request/UpdateMemoRequestDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/dto/request/UpdateMemoRequestDTO.java
@@ -5,11 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-@Schema(description = "메모 생성 요청 DTO")
-public class CreateMemoRequestDTO {
+public class UpdateMemoRequestDTO {
 
 	@Schema(description = "메모 내용", example = "장보기, 운동하기, 책 읽기")
 	@NotBlank(message = "메모의 내용을 입력해야합니다.")
 	private String content;
-
+	
 }

--- a/src/main/java/com/indayvidual/server/domain/memo/dto/response/MemoDetailResponseDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/dto/response/MemoDetailResponseDTO.java
@@ -22,9 +22,6 @@ public class MemoDetailResponseDTO {
 	@Schema(description = "메모 ID", example = "3")
 	private Long memoId;
 
-	@Schema(description = "메모 제목", example = "메모 제목")
-	private String title;
-	
 	@Schema(description = "메모 내용", example = "메모 내용")
 	private String content;
 

--- a/src/main/java/com/indayvidual/server/domain/memo/dto/response/MemoSummaryResponseDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/dto/response/MemoSummaryResponseDTO.java
@@ -36,7 +36,6 @@ public class MemoSummaryResponseDTO {
 	public static MemoSummaryResponseDTO from(Memo memo) {
 		return MemoSummaryResponseDTO.builder()
 			.id(memo.getId())
-			.title(memo.getTitle())
 			.contentPreview(memo.getContent())
 			.createdAt(memo.getCreatedAt())
 			.updatedAt(memo.getUpdatedAt())

--- a/src/main/java/com/indayvidual/server/domain/memo/entity/Memo.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/entity/Memo.java
@@ -43,21 +43,21 @@ public class Memo extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	private String title;
-
 	@Lob
 	private String content;
 
 	//== 생성 메서드 ==//
-	public static Memo createMemo(String title, String content, User user) {
+	public static Memo createMemo(String content, User user) {
 		return Memo.builder()
 			.user(user)
-			.title(title)
 			.content(content)
 			.build();
 	}
 
 	//== 더티체킹 메서드 ==//
+	public void updateContent(String content) {
+		this.content = content;
+	}
 
 	//== 비즈니스 로직 ==//
 	public boolean isOwnerBy(User user) {

--- a/src/main/java/com/indayvidual/server/domain/memo/service/command/MemoCommandService.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/service/command/MemoCommandService.java
@@ -1,6 +1,7 @@
 package com.indayvidual.server.domain.memo.service.command;
 
 import com.indayvidual.server.domain.memo.dto.request.CreateMemoRequestDTO;
+import com.indayvidual.server.domain.memo.dto.request.UpdateMemoRequestDTO;
 import com.indayvidual.server.domain.memo.dto.response.MemoDetailResponseDTO;
 
 public interface MemoCommandService {
@@ -8,5 +9,7 @@ public interface MemoCommandService {
 	MemoDetailResponseDTO createMemo(Long userId, CreateMemoRequestDTO requestDTO);
 
 	Void deleteMemo(Long userId, Long memoId);
+
+	MemoDetailResponseDTO updateMemo(Long userId, Long memoId, UpdateMemoRequestDTO request);
 
 }

--- a/src/main/java/com/indayvidual/server/domain/memo/service/command/MemoCommandServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/memo/service/command/MemoCommandServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.indayvidual.server.domain.memo.dto.request.CreateMemoRequestDTO;
+import com.indayvidual.server.domain.memo.dto.request.UpdateMemoRequestDTO;
 import com.indayvidual.server.domain.memo.dto.response.MemoDetailResponseDTO;
 import com.indayvidual.server.domain.memo.entity.Memo;
 import com.indayvidual.server.domain.memo.exception.MemoException;
@@ -29,7 +30,7 @@ public class MemoCommandServiceImpl implements MemoCommandService {
 	public MemoDetailResponseDTO createMemo(Long userId, CreateMemoRequestDTO requestDTO) {
 		User currentUser = getCurrentUser(userId);
 
-		Memo newMemo = Memo.createMemo(requestDTO.getTitle(), requestDTO.getContent(), currentUser);
+		Memo newMemo = Memo.createMemo(requestDTO.getContent(), currentUser);
 
 		memoRepository.save(newMemo);
 
@@ -41,14 +42,29 @@ public class MemoCommandServiceImpl implements MemoCommandService {
 	public Void deleteMemo(Long userId, Long memoId) {
 		User currentUser = getCurrentUser(userId);
 
-		Memo memo = memoRepository.findById(memoId)
-			.orElseThrow(() -> new MemoException(ErrorStatus.MEMO_NOT_FOUND));
+		Memo memo = getMemo(memoId);
 
 		if (memo.canDeleteMemo(currentUser)) {
 			memoRepository.delete(memo);
 		}
 
 		return null;
+	}
+
+	@Override
+	public MemoDetailResponseDTO updateMemo(Long userId, Long memoId, UpdateMemoRequestDTO request) {
+		User currentUser = getCurrentUser(userId);
+
+		Memo memo = getMemo(memoId);
+
+		memo.updateContent(request.getContent());
+
+		return MemoDetailResponseDTO.from(memo);
+	}
+
+	private Memo getMemo(Long memoId) {
+		return memoRepository.findById(memoId)
+			.orElseThrow(() -> new MemoException(ErrorStatus.MEMO_NOT_FOUND));
 	}
 
 	private User getCurrentUser(Long userId) {


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
- `PATCH /memos/{memoId}` API 추가로 메모 수정 기능 구현
- `UpdateMemoRequestDTO` 생성 및 관련 로직 연동
- 제목 필드 제거, 메모는 내용 필드만 유지하도록 수정
- CI/CD 워크플로우에서 develop 브랜치 병합 조건 추가

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #58 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- `PATCH /memos/{memoId}` API 추가로 메모 수정 기능 구현
- `UpdateMemoRequestDTO` 생성 및 관련 로직 연동
- 제목 필드 제거, 메모는 내용 필드만 유지하도록 수정
- CI/CD 워크플로우에서 develop 브랜치 병합 조건 추가

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 