### PR TITLE
[FEAT] 마이페이지 프로필 조회 및 수정 기능 구현 #49

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/indayvidual/server/domain/user/controller/UserProfileController.java
@@ -1,0 +1,59 @@
+package com.indayvidual.server.domain.user.controller;
+
+import com.indayvidual.server.domain.user.dto.request.UserRequestDTO;
+import com.indayvidual.server.domain.user.dto.response.UserResponseDTO;
+import com.indayvidual.server.domain.user.service.UserService.UserProfileService;
+import com.indayvidual.server.global.api.response.ApiResponse;
+import com.indayvidual.server.global.config.security.JwtUserPrincipal;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "MyPage API", description = "마이페이지 기능 제공")
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class UserProfileController {
+
+    private final UserProfileService userProfileService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<UserResponseDTO.Profile>> getMyProfile(
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        var profile = userProfileService.getMyProfile(principal.userId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(profile));
+    }
+
+    @PatchMapping("/update_username")
+    public ResponseEntity<ApiResponse<String>> updateUsername(
+            @AuthenticationPrincipal JwtUserPrincipal principal,
+            @RequestBody @Valid UserRequestDTO.UpdateUsername dto
+    ) {
+        userProfileService.updateUsername(principal.userId(), dto.getUsername());
+        return ResponseEntity.ok(ApiResponse.onSuccess("닉네임이 변경되었습니다."));
+    }
+
+    @PatchMapping("/update_password")
+    public ResponseEntity<ApiResponse<String>> updatePassword(
+            @AuthenticationPrincipal JwtUserPrincipal principal,
+            @RequestBody @Valid UserRequestDTO.UpdatePassword dto
+    ) {
+        userProfileService.updatePassword(principal.userId(), dto.getCurrentPassword(), dto.getNewPassword());
+        return ResponseEntity.ok(ApiResponse.onSuccess("비밀번호가 변경되었습니다."));
+    }
+
+    @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<String>> updateProfileImage(
+            @AuthenticationPrincipal JwtUserPrincipal principal,
+            @RequestPart("image") MultipartFile image
+    ) {
+        String url = userProfileService.updateProfileImage(principal.userId(), image);
+        return ResponseEntity.ok(ApiResponse.onSuccess(url));
+    }
+}

--- a/src/main/java/com/indayvidual/server/domain/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/user/dto/request/UserRequestDTO.java
@@ -1,0 +1,27 @@
+package com.indayvidual.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+public class UserRequestDTO {
+
+    @Getter
+    public static class UpdateUsername {
+        @NotBlank
+        @Size(min = 2, max = 20)
+        private String username;
+    }
+
+    @Getter
+    public static class UpdatePassword {
+        @NotBlank
+        private String currentPassword;
+        @NotBlank
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        private String newPassword;
+    }
+
+    // 이미지 업로드는 Multipart 사용 (컨트롤러에서 @RequestPart 로 받음)
+    // 필요 시 URL만 받는 방식(프리사인드 업로드) DTO도 추가 가능
+}

--- a/src/main/java/com/indayvidual/server/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/indayvidual/server/domain/user/dto/response/UserResponseDTO.java
@@ -1,0 +1,18 @@
+package com.indayvidual.server.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class UserResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Profile {
+        private Long userId;
+        private String email;
+        private String username;
+        private String imageUrl; // user.profile_image 매핑
+    }
+}

--- a/src/main/java/com/indayvidual/server/domain/user/entity/User.java
+++ b/src/main/java/com/indayvidual/server/domain/user/entity/User.java
@@ -47,8 +47,10 @@ public class User extends BaseEntity {
 	private String email;
 	private String password;  // (소셜 로그인 시 null)
 	private String username;
-	private String profile_image;
 	private String phone_number;
+
+	@Column(name = "profile_image", length = 512)
+	private String profile_image;
 
 	@Enumerated(EnumType.STRING)
 	private Status status;
@@ -67,5 +69,9 @@ public class User extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<Habit> habits = new ArrayList<>();
+
+	public void changeUsername(String username) { this.username = username; }
+	public void changePassword(String encodedPassword) { this.password = encodedPassword; }
+	public void changeProfileImage(String imageUrl) { this.profile_image = imageUrl; }
 
 }

--- a/src/main/java/com/indayvidual/server/domain/user/service/UserService/S3Uploader.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/UserService/S3Uploader.java
@@ -1,0 +1,109 @@
+package com.indayvidual.server.domain.user.service.UserService;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import java.io.IOException;
+
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.indayvidual.server.global.api.code.status.ErrorStatus;
+import com.indayvidual.server.global.exception.GeneralException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @PostConstruct
+    void check() {
+        log.info("S3 bucket='{}'", bucket);
+        try {
+            // 존재/권한/리전 확인 (HeadBucket 권한 필요)
+            amazonS3Client.headBucket(new com.amazonaws.services.s3.model.HeadBucketRequest(bucket));
+            String loc = amazonS3Client.getBucketLocation(bucket);
+            log.info("✅ S3 bucket OK. location={}", loc);
+        } catch (com.amazonaws.services.s3.model.AmazonS3Exception e) {
+            log.error("❌ S3 check failed: code={}, status={}, msg={}", e.getErrorCode(), e.getStatusCode(), e.getMessage());
+            // 부팅을 살리고 싶으면 예외를 다시 던지지 마세요.
+        } catch (com.amazonaws.SdkClientException e) {
+            log.error("❌ S3 SDK client error: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("❌ Unexpected error in S3 check", e);
+        }
+    }
+
+    // 확장자 추출 유틸
+    private String extOf(String originalFileName) {
+        if (originalFileName == null) return "";
+        int idx = originalFileName.lastIndexOf('.');
+        return (idx != -1) ? originalFileName.substring(idx + 1) : "";
+    }
+
+    public String uploadProfileImage(Long userId, MultipartFile file) {
+        if (file == null || file.isEmpty()) return null;
+
+        try {
+            String ext = extOf(file.getOriginalFilename());
+            String key = String.format("profiles/%d/%s.%s",
+                    userId, UUID.randomUUID(), (ext.isBlank() ? "jpg" : ext));
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getSize());
+
+            // 공개 URL이 필요하다면 퍼블릭 리드 ACL (버킷 정책과 보안정책에 따라 조정)
+            PutObjectRequest req = new PutObjectRequest(bucket, key, file.getInputStream(), metadata);
+
+            amazonS3Client.putObject(req);
+            String url = amazonS3Client.getUrl(bucket, key).toString();
+
+            return generateReadUrl(bucket, key, Duration.ofHours(24));
+
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void deleteObjectByUrl(String url) {
+        if (url == null || url.isBlank()) return;
+        try {
+            // url → key 변환 (버킷 호스트 제거)
+            URI uri = URI.create(url);
+            String key = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
+            amazonS3Client.deleteObject(bucket, key);
+        } catch (Exception e) {
+            log.warn("S3 delete skip. url={}, err={}", url, e.getMessage());
+        }
+    }
+
+    public String generateReadUrl(String bucket, String key, Duration ttl) {
+        var expires = Date.from(Instant.now().plus(ttl));
+        GeneratePresignedUrlRequest req =
+                new GeneratePresignedUrlRequest(bucket, key)
+                        .withMethod(HttpMethod.GET)
+                        .withExpiration(expires);
+        URL signedUrl = amazonS3Client.generatePresignedUrl(req);
+        return signedUrl.toString();
+    }
+}
+

--- a/src/main/java/com/indayvidual/server/domain/user/service/UserService/UserProfileService.java
+++ b/src/main/java/com/indayvidual/server/domain/user/service/UserService/UserProfileService.java
@@ -1,0 +1,77 @@
+package com.indayvidual.server.domain.user.service.UserService;
+
+import com.indayvidual.server.domain.user.dto.response.UserResponseDTO;
+import com.indayvidual.server.domain.user.entity.User;
+import com.indayvidual.server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final S3Uploader s3Uploader;
+
+    @Value("${app.profile.default-image-url:https://.../default_profile.png}")
+    private String defaultProfileImageUrl;
+
+    @Transactional(readOnly = true)
+    public UserResponseDTO.Profile getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        String img = (user.getProfile_image() == null || user.getProfile_image().isBlank())
+                ? defaultProfileImageUrl
+                : user.getProfile_image();
+
+        return UserResponseDTO.Profile.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .imageUrl(img)
+                .build();
+    }
+
+    public void updateUsername(Long userId, String newUsername) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.changeUsername(newUsername);
+    }
+
+    public void updatePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            throw new IllegalArgumentException("기존 비밀번호와 동일합니다.");
+        }
+        user.changePassword(passwordEncoder.encode(newPassword));
+    }
+
+    public String updateProfileImage(Long userId, MultipartFile image) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        String oldUrl = user.getProfile_image();
+
+        // 업로드
+        String newUrl = s3Uploader.uploadProfileImage(userId, image);
+        user.changeProfileImage(newUrl);
+
+        // 이전 이미지가 기본이미지가 아닌 경우 삭제
+        if (oldUrl != null && !oldUrl.isBlank() && !oldUrl.equals(defaultProfileImageUrl)) {
+            s3Uploader.deleteObjectByUrl(oldUrl);
+        }
+        return newUrl;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -69,3 +69,6 @@ kakao:
     token-info-uri:  https://kapi.kakao.com/v1/user/access_token_info
     user-info-uri:   https://kapi.kakao.com/v2/user/me
 
+app:
+  profile:
+    default-image-url: https://indayvidual.s3.ap-northeast-2.amazonaws.com/base_image.png


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
사용자 마이페이지 기능 중 다음 기능을 구현

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #49 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- User 엔티티에 profileImage 필드 추가 및 초기 기본 이미지 설정
- S3Uploader 클래스 추가: 프로필 이미지 업로드 기능 구현
- AmazonS3 빈 등록 및 S3 연동 설정 추가

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 