### PR TITLE
[FEAT] 색상 목록 조회 api 추가 #16

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/todo/controller/ColorController.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/controller/ColorController.java
@@ -1,0 +1,31 @@
+package com.indayvidual.server.domain.todo.controller;
+
+import com.indayvidual.server.domain.todo.service.color.ColorQueryService;
+import com.indayvidual.server.global.api.code.status.SuccessStatus;
+import com.indayvidual.server.global.api.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Color", description = "Color 관련 API")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/colors")
+public class ColorController {
+
+    private final ColorQueryService colorQueryService;
+
+    @Operation(summary = "색상 목록 조회", description = "색상 목록을 조회합니다.")
+    @GetMapping("")
+    public ApiResponse<List<String>> getColors() {
+        return ApiResponse.onSuccess(
+                colorQueryService.findAll(),
+                SuccessStatus.GET_COLORS_SUCCESS.getCode(),
+                SuccessStatus.GET_COLORS_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/indayvidual/server/domain/todo/controller/TodoCategoryController.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/controller/TodoCategoryController.java
@@ -4,6 +4,7 @@ import com.indayvidual.server.domain.todo.dto.request.CategoryCreateRequestDTO;
 import com.indayvidual.server.domain.todo.dto.response.CategoryResponseDTO;
 import com.indayvidual.server.domain.todo.service.category.CategoryCommandService;
 import com.indayvidual.server.domain.todo.service.category.CategoryQueryService;
+import com.indayvidual.server.global.api.code.status.SuccessStatus;
 import com.indayvidual.server.global.api.response.ApiResponse;
 import com.indayvidual.server.global.util.Utils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,7 +22,6 @@ import java.util.List;
 @Slf4j
 @RequestMapping("/api/todo/categories")
 public class TodoCategoryController {
-    // TODO: success status 추가
 
     private final CategoryCommandService categoryCommandService;
     private final CategoryQueryService categoryQueryService;
@@ -31,13 +30,19 @@ public class TodoCategoryController {
     @PostMapping("")
     public ApiResponse<CategoryResponseDTO> createCategory(@RequestBody @Valid CategoryCreateRequestDTO request) {
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(categoryCommandService.create(request, userId));
+        return ApiResponse.onSuccess(
+                categoryCommandService.create(request, userId),
+                SuccessStatus.CREATE_CATEGORY_SUCCESS.getCode(),
+                SuccessStatus.CREATE_CATEGORY_SUCCESS.getMessage());
     }
 
     @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
     @GetMapping("")
     public ApiResponse<List<CategoryResponseDTO>> getCategories() {
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(categoryQueryService.findAll(userId));
+        return ApiResponse.onSuccess(
+                categoryQueryService.findAll(userId),
+                SuccessStatus.GET_CATEGORIES_SUCCESS.getCode(),
+                SuccessStatus.GET_CATEGORIES_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/indayvidual/server/domain/todo/controller/TodoTaskController.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/controller/TodoTaskController.java
@@ -6,6 +6,7 @@ import com.indayvidual.server.domain.todo.dto.response.TaskResponseDTO;
 import com.indayvidual.server.domain.todo.dto.response.TaskUpdateResponseDTO;
 import com.indayvidual.server.domain.todo.service.task.TaskCommandService;
 import com.indayvidual.server.domain.todo.service.task.TaskQueryService;
+import com.indayvidual.server.global.api.code.status.SuccessStatus;
 import com.indayvidual.server.global.api.response.ApiResponse;
 import com.indayvidual.server.global.util.Utils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,7 +16,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -27,7 +27,6 @@ import java.util.List;
 @Slf4j
 @RequestMapping("/api/todo")
 public class TodoTaskController {
-    // TODO: success status 추가
 
     private final TaskCommandService taskCommandService;
     private final TaskQueryService taskQueryService;
@@ -43,10 +42,12 @@ public class TodoTaskController {
             )
             @RequestParam("date")
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        // TODO: local date 형식 예외 처리 추가
 
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(taskQueryService.findTasksByCategoryAndDate(userId, categoryId, date));
+        return ApiResponse.onSuccess(
+                taskQueryService.findTasksByCategoryAndDate(userId, categoryId, date),
+                SuccessStatus.GET_TASKS_SUCCESS.getCode(),
+                SuccessStatus.GET_TASKS_SUCCESS.getMessage());
     }
 
     @Operation(summary = "할 일 등록", description = "새로운 할 일을 등록합니다.")
@@ -56,7 +57,10 @@ public class TodoTaskController {
             @RequestBody @Valid TaskCreateRequestDTO request) {
 
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(taskCommandService.createTask(userId, categoryId, request));
+        return ApiResponse.onSuccess(
+                taskCommandService.createTask(userId, categoryId, request),
+                SuccessStatus.CREATE_TASK_SUCCESS.getCode(),
+                SuccessStatus.CREATE_TASK_SUCCESS.getMessage());
     }
 
     @Operation(summary = "할 일 제목 수정", description = "할 일의 제목을 수정합니다.")
@@ -66,7 +70,10 @@ public class TodoTaskController {
             @RequestBody @Valid TaskTitleUpdateRequestDTO request) {
 
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(taskCommandService.updateTaskTitle(userId, taskId, request));
+        return ApiResponse.onSuccess(
+                taskCommandService.updateTaskTitle(userId, taskId, request),
+                SuccessStatus.UPDATE_TASK_TITLE_SUCCESS.getCode(),
+                SuccessStatus.UPDATE_TASK_TITLE_SUCCESS.getMessage());
     }
 
     @Operation(summary = "할 일 날짜 수정", description = "할 일의 날짜를 수정합니다.")
@@ -74,10 +81,12 @@ public class TodoTaskController {
     public ApiResponse<TaskResponseDTO> updateTaskDueDate(
             @PathVariable Long taskId,
             @RequestBody @Valid TaskDueDateUpdateRequestDTO request) {
-        // TODO: local date 형식 예외 처리 추가
 
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(taskCommandService.updateTaskDueDate(userId, taskId, request));
+        return ApiResponse.onSuccess(
+                taskCommandService.updateTaskDueDate(userId, taskId, request),
+                SuccessStatus.UPDATE_TASK_DUE_DATE_SUCCESS.getCode(),
+                SuccessStatus.UPDATE_TASK_DUE_DATE_SUCCESS.getMessage());
     }
 
     @Operation(summary = "할 일 삭제", description = "할 일을 삭제합니다.")
@@ -85,14 +94,20 @@ public class TodoTaskController {
     public ApiResponse<Void> deleteTask(@PathVariable Long taskId) {
         Long userId = Utils.getUserId();
         taskCommandService.deleteTask(userId, taskId);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess(
+                null,
+                SuccessStatus.DELETE_TASK_SUCCESS.getCode(),
+                SuccessStatus.DELETE_TASK_SUCCESS.getMessage());
     }
 
     @Operation(summary = "할 일 체크/체크 해제", description = "할 일을 체크하거나 체크 해제합니다.")
     @PatchMapping("/tasks/{taskId}/check")
     public ApiResponse<TaskCheckUpdateResponseDTO> updateTaskStatus(@PathVariable Long taskId) {
         Long userId = Utils.getUserId();
-        return ApiResponse.onSuccess(taskCommandService.toggleCheck(userId, taskId));
+        return ApiResponse.onSuccess(
+                taskCommandService.toggleCheck(userId, taskId),
+                SuccessStatus.UPDATE_TASK_CHECK_SUCCESS.getCode(),
+                SuccessStatus.UPDATE_TASK_CHECK_SUCCESS.getMessage());
     }
 
     @Operation(summary = "할 일 순서 변경",
@@ -109,7 +124,10 @@ public class TodoTaskController {
         //TODO : 카테고리 변경도 추가하기
         Long userId = Utils.getUserId();
         taskCommandService.updateTaskOrder(userId, categoryId, request);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess(
+                null,
+                SuccessStatus.UPDATE_TASK_ORDER_SUCCESS.getCode(),
+                SuccessStatus.UPDATE_TASK_ORDER_SUCCESS.getMessage());
     }
 }
 

--- a/src/main/java/com/indayvidual/server/domain/todo/converter/CategoryConverter.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/converter/CategoryConverter.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 public class CategoryConverter {
 
     public Category toEntity(CategoryCreateRequestDTO request, User user) {
-        // TODO : static method로 수정
         return Category.builder()
                 .user(user)
                 .title(request.getName())

--- a/src/main/java/com/indayvidual/server/domain/todo/converter/TaskConverter.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/converter/TaskConverter.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 public class TaskConverter {
 
     public Task toEntity(TaskCreateRequestDTO dto, Category category, User user, Integer position) {
-        // TODO : static method로 수정
         return Task.builder()
                 .user(user)
                 .category(category)

--- a/src/main/java/com/indayvidual/server/domain/todo/entity/Color.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/entity/Color.java
@@ -1,0 +1,26 @@
+package com.indayvidual.server.domain.todo.entity;
+
+import com.indayvidual.server.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name="color")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Color extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 10, nullable = false)
+    private String color_code;
+}

--- a/src/main/java/com/indayvidual/server/domain/todo/repository/ColorRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/repository/ColorRepository.java
@@ -1,0 +1,13 @@
+package com.indayvidual.server.domain.todo.repository;
+
+import com.indayvidual.server.domain.todo.entity.Color;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ColorRepository extends JpaRepository<Color, Long> {
+
+    @Query("SELECT c.color_code FROM Color c ORDER BY c.id ASC")
+    List<String> findAllColorCodes();
+}

--- a/src/main/java/com/indayvidual/server/domain/todo/service/color/ColorQueryService.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/service/color/ColorQueryService.java
@@ -1,0 +1,20 @@
+package com.indayvidual.server.domain.todo.service.color;
+
+import com.indayvidual.server.domain.todo.entity.Color;
+import com.indayvidual.server.domain.todo.repository.ColorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ColorQueryService {
+
+    private final ColorRepository colorRepository;
+
+    public List<String> findAll() {
+        List<String> colors = colorRepository.findAllColorCodes();
+        return colors;
+    }
+}

--- a/src/main/java/com/indayvidual/server/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/indayvidual/server/global/api/code/status/SuccessStatus.java
@@ -37,7 +37,10 @@ public enum SuccessStatus implements BaseCode {
     UPDATE_TASK_DUE_DATE_SUCCESS(HttpStatus.OK, "UPDATE_TASK_DUEDATE_SUCCESS", "할일 날짜 수정 성공"),
     DELETE_TASK_SUCCESS(HttpStatus.OK, "DELETE_TASK_SUCCESS", "할일 삭제 성공"),
     UPDATE_TASK_CHECK_SUCCESS(HttpStatus.OK, "UPDATE_TASK_CHECK_SUCCESS", "할일 체크 상태 변경 성공"),
-    UPDATE_TASK_ORDER_SUCCESS(HttpStatus.OK, "UPDATE_TASK_ORDER_SUCCESS", "할일 순서 변경 성공")
+    UPDATE_TASK_ORDER_SUCCESS(HttpStatus.OK, "UPDATE_TASK_ORDER_SUCCESS", "할일 순서 변경 성공"),
+
+    // 색상 관련 응답
+    GET_COLORS_SUCCESS(HttpStatus.OK, "GET_COLORS_SUCCESS", "색상 목록 조회 성공")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
색상 목록 조회 api 구현

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #16

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 색상 목록 조회 api 구현

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 
<img width="813" height="608" alt="스크린샷 2025-07-30 오전 3 44 26" src="https://github.com/user-attachments/assets/86765826-3e88-4337-8eb5-2c41d7171ad0" />



## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 