### PR TITLE
[REFACTOR] 캘린더, 일정 관련 API 수정: color id #75

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetDayEventResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetDayEventResponseDto.java
@@ -21,5 +21,5 @@ public class GetDayEventResponseDto {
 
     private String endTime;
 
-    private String color;
+    private Long colorId;
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetMonthlyCalendarResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/dto/response/GetMonthlyCalendarResponseDto.java
@@ -20,6 +20,6 @@ public class GetMonthlyCalendarResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
-    @Schema(description = "해당 날짜에 포함된 일정의 색상 코드 리스트", example = "[\"#FF0000\", \"#00FF00\"]")
-    private List<String> colors;
+    @Schema(description = "해당 날짜에 포함된 일정의 색상 ID 리스트", example = "[1, 2]")
+    private List<Long> colorIds;
 }

--- a/src/main/java/com/indayvidual/server/domain/calendar/service/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/calendar/service/CalendarQueryServiceImpl.java
@@ -39,19 +39,19 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
 
         List<Event> events = eventRepository.findByUserIdAndEventDateBetween(userId, startDate, endDate);
 
-        Map<LocalDate, List<String>> dateColorsMap = events.stream()
+        Map<LocalDate, List<Long>> dateColorIdsMap = events.stream()
                 .collect(Collectors.groupingBy(
                         Event::getEventDate,
-                        Collectors.mapping(Event::getColorCode, Collectors.toList())
+                        Collectors.mapping(event -> event.getColor().getId(), Collectors.toList())
                 ));
 
         return Stream.iterate(startDate, date -> date.plusDays(1))
                 .limit(yearMonth.lengthOfMonth())
                 .map(date -> {
-                    List<String> colors = dateColorsMap.getOrDefault(date, Collections.emptyList());
+                    List<Long> colorIds = dateColorIdsMap.getOrDefault(date, Collections.emptyList());
                     return GetMonthlyCalendarResponseDto.builder()
                             .date(date)
-                            .colors(colors)
+                            .colorIds(colorIds)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/indayvidual/server/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/indayvidual/server/domain/event/converter/EventConverter.java
@@ -3,9 +3,13 @@ package com.indayvidual.server.domain.event.converter;
 import com.indayvidual.server.domain.event.dto.request.CreateEventRequestDto;
 import com.indayvidual.server.domain.event.dto.request.UpdateEventRequestDto;
 import com.indayvidual.server.domain.event.dto.response.CreateEventResponseDto;
-import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.event.dto.response.UpdateEventResponseDto;
+import com.indayvidual.server.domain.calendar.dto.response.GetDayEventResponseDto;
 import com.indayvidual.server.domain.event.entity.Event;
+import com.indayvidual.server.domain.event.exception.EventException;
+import com.indayvidual.server.domain.todo.entity.Color;
+import com.indayvidual.server.domain.todo.repository.ColorRepository;
+import com.indayvidual.server.global.api.code.status.ErrorStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -16,9 +20,15 @@ import java.time.format.DateTimeFormatter;
 public class EventConverter {
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-    private static final String DEFAULT_COLOR = "#CD7AFB";
+    private static final Long DEFAULT_COLOR_ID = 1L;
     private static final LocalTime ALL_DAY_START_TIME = LocalTime.of(0, 0);
     private static final LocalTime ALL_DAY_END_TIME = LocalTime.of(23, 59);
+
+    private final ColorRepository colorRepository;
+
+    public EventConverter(ColorRepository colorRepository) {
+        this.colorRepository = colorRepository;
+    }
 
     public Event toEntity(CreateEventRequestDto request, Long userId) {
         LocalTime startTime;
@@ -32,33 +42,19 @@ public class EventConverter {
             endTime = request.getEndTime();
         }
 
+        Long colorId = request.getColorId() != null ? request.getColorId() : DEFAULT_COLOR_ID;
+        Color color = colorRepository.findById(colorId)
+                .orElseThrow(() -> new EventException(ErrorStatus.EVENT_INVALID_COLOR_ID));
+
         return Event.builder()
                 .userId(userId)
                 .title(request.getTitle().trim())
                 .eventDate(request.getDate())
                 .startTime(startTime)
                 .endTime(endTime)
-                .colorCode(StringUtils.hasText(request.getColor()) ? request.getColor() : DEFAULT_COLOR)
+                .color(color)
                 .userEndTime(endTime != null)
                 .isAllDay(Boolean.TRUE.equals(request.getIsAllDay()))
-                .build();
-    }
-
-    public CreateEventResponseDto toCreateResponse(Event entity) {
-        return CreateEventResponseDto.builder()
-                .eventId(entity.getId())
-                .build();
-    }
-
-    public UpdateEventResponseDto toUpdateResponse(Event entity) {
-        return UpdateEventResponseDto.builder()
-                .eventId(entity.getId())
-                .date(entity.getEventDate())
-                .title(entity.getTitle())
-                .startTime(entity.getStartTime())
-                .endTime(entity.getEndTime())
-                .color(entity.getColorCode())
-                .isAllDay(entity.getIsAllDay())
                 .build();
     }
 
@@ -97,9 +93,29 @@ public class EventConverter {
             }
         }
 
-        if (StringUtils.hasText(request.getColor())) {
-            entity.setColorCode(request.getColor());
+        if (request.getColorId() != null) {
+            Color color = colorRepository.findById(request.getColorId())
+                    .orElseThrow(() -> new EventException(ErrorStatus.EVENT_INVALID_COLOR_ID));
+            entity.setColor(color);
         }
+    }
+
+    public CreateEventResponseDto toCreateResponse(Event entity) {
+        return CreateEventResponseDto.builder()
+                .eventId(entity.getId())
+                .build();
+    }
+
+    public UpdateEventResponseDto toUpdateResponse(Event entity) {
+        return UpdateEventResponseDto.builder()
+                .eventId(entity.getId())
+                .date(entity.getEventDate())
+                .title(entity.getTitle())
+                .startTime(entity.getStartTime())
+                .endTime(entity.getEndTime())
+                .colorId(entity.getColor().getId())
+                .isAllDay(entity.getIsAllDay())
+                .build();
     }
 
     public GetDayEventResponseDto toGetDayEventResponse(Event event) {
@@ -109,8 +125,7 @@ public class EventConverter {
                 .title(event.getTitle())
                 .startTime(event.getStartTime().format(TIME_FORMATTER))
                 .endTime(event.getEndTime() != null ? event.getEndTime().format(TIME_FORMATTER) : null)
-                .color(event.getColorCode())
+                .colorId(event.getColor().getId())
                 .build();
     }
-
 }

--- a/src/main/java/com/indayvidual/server/domain/event/dto/request/CreateEventRequestDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/request/CreateEventRequestDto.java
@@ -37,9 +37,8 @@ public class CreateEventRequestDto {
     @JsonFormat(pattern = "HH:mm")
     private LocalTime endTime;
 
-    @Schema(description = "색상 코드", example = "#CD7AFB")
-    @Pattern(regexp = "^#[0-9A-F]{6}$", message = "색상은 #RRGGBB 형식이어야 합니다.")
-    private String color;
+    @Schema(description = "색상 ID", example = "1")
+    private Long colorId;
 
     @Schema(description = "하루종일 여부", example = "false")
     @Builder.Default

--- a/src/main/java/com/indayvidual/server/domain/event/dto/request/UpdateEventRequestDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/request/UpdateEventRequestDto.java
@@ -34,9 +34,8 @@ public class UpdateEventRequestDto {
     @JsonFormat(pattern = "HH:mm")
     private LocalTime endTime;
 
-    @Schema(description = "색상 코드", example = "#CD7AFB")
-    @Pattern(regexp = "^#[0-9A-F]{6}$", message = "색상은 #RRGGBB 형식이어야 합니다.")
-    private String color;
+    @Schema(description = "색상 ID", example = "1")
+    private Long colorId;
 
     @Schema(description = "하루종일 여부", example = "false")
     private Boolean isAllDay;

--- a/src/main/java/com/indayvidual/server/domain/event/dto/response/UpdateEventResponseDto.java
+++ b/src/main/java/com/indayvidual/server/domain/event/dto/response/UpdateEventResponseDto.java
@@ -33,8 +33,8 @@ public class UpdateEventResponseDto {
     @JsonFormat(pattern = "HH:mm")
     private LocalTime endTime;
 
-    @Schema(description = "색상 코드", example = "#CD7AFB")
-    private String color;
+    @Schema(description = "색상 ID", example = "1")
+    private Long colorId;
 
     @Schema(description = "하루종일 여부", example = "false")
     private Boolean isAllDay;

--- a/src/main/java/com/indayvidual/server/domain/event/entity/Event.java
+++ b/src/main/java/com/indayvidual/server/domain/event/entity/Event.java
@@ -1,6 +1,7 @@
 package com.indayvidual.server.domain.event.entity;
 
 import com.indayvidual.server.common.BaseEntity;
+import com.indayvidual.server.domain.todo.entity.Color;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -34,9 +35,10 @@ public class Event extends BaseEntity {
     @Column(name = "end_time", nullable = true)
     private LocalTime endTime;
 
-    @Column(name = "color_code", nullable = false, length = 7)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "color_id", nullable = false)
     @Builder.Default
-    private String colorCode = "#CD7AFB";
+    private Color color = null;
 
     @Column(name = "user_end_time", nullable = false)
     @Builder.Default

--- a/src/main/java/com/indayvidual/server/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/indayvidual/server/global/api/code/status/ErrorStatus.java
@@ -76,6 +76,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_GET_BY_DATE_FAILED(HttpStatus.BAD_REQUEST, "EVENT4006", "특정 날짜 일정 조회에 실패했습니다."),
     EVENT_INVALID_TIME_ORDER(HttpStatus.BAD_REQUEST, "EVENT4007", "시작 시간은 종료 시간보다 빨라야 합니다."),
     EVENT_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "EVENT4008", "날짜 형식이 올바르지 않습니다."),
+    EVENT_INVALID_COLOR_ID(HttpStatus.BAD_REQUEST, "EVENT4009", "유효하지 않은 색상 ID입니다."),
 
     // ===== 시간표 관련 에러 (TIMETABLE) =====
     TIMETABLE_CREATE_FAILED(HttpStatus.BAD_REQUEST, "TIMETABLE4001", "시간표 등록에 실패했습니다."),


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
캘린더, 일정 관련 API에서 color code를 직접 사용 -> color id 로 사용하도록 수정합니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #75 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 캘린더, 일정 관련 API에서 color code를 직접 사용하던 방식에서 color 테이블의 각 색상별 id를 사용하도록 합니다.

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 