### PR TITLE
[REFACTOR] Nginx 'client_max_body_size' 20MB로 설정 #97

### DIFF
--- a/.platform/nginx/conf.d/client-size-timeout.conf
+++ b/.platform/nginx/conf.d/client-size-timeout.conf
@@ -1,0 +1,4 @@
+client_max_body_size 20m;     # 업로드 최대 용량
+client_body_timeout 120s;     # 업로드 타임아웃
+proxy_read_timeout 120s;      # 백엔드 응답 대기
+proxy_send_timeout 120s;      # 백엔드로 전송 대기


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Elastic Beanstalk Nginx 업로드 용량 확대 및 Spring Multipart 제한 조정

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #97 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- `.platform/nginx/conf.d/client-size-timeout.conf` 추가

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 