### PR TITLE
[FIX] task 조회 메서드 수정 #107

### DIFF
--- a/src/main/java/com/indayvidual/server/domain/todo/repository/TaskRepository.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/repository/TaskRepository.java
@@ -20,15 +20,16 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findByUserIdAndCategoryIdAndDueDate(Long userId, Long categoryId, LocalDate date);
 
     /**
-     * 카테고리 내에서 현재 등록된 Task의 최대 position을 조회합니다.
+     * 특정 날짜와 카테고리 내에서 현재 등록된 Task의 최대 position을 조회합니다.
      * <p>
      * - 새로운 Task 생성 시 position 지정에 사용됩니다.
+     * - 값이 없으면 null을 반환합니다.
      *
      * @param categoryId
+     * @param date
      * @return max position 값 (null 가능)
      */
-    @Query("SELECT MAX(t.position) FROM Task t WHERE t.category.id = :categoryId")
-    Integer findMaxPositionByCategoryId(@Param("categoryId") Long categoryId);
+    Integer findTopByCategoryIdAndDueDateOrderByPositionDesc(Long categoryId, LocalDate date);
 
     List<Task> findAllByUserIdAndCategoryId(Long userId, Long categoryId);
 

--- a/src/main/java/com/indayvidual/server/domain/todo/service/task/TaskCommandServiceImpl.java
+++ b/src/main/java/com/indayvidual/server/domain/todo/service/task/TaskCommandServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -46,7 +47,7 @@ public class TaskCommandServiceImpl implements TaskCommandService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TASK_CATEGORY_NOT_FOUND));
 
         // position 지정
-        Integer position = generateNextPosition(categoryId);
+        Integer position = generateNextPosition(categoryId, request.getDate());
 
         Task task = taskConverter.toEntity(request, category, user, position);
         taskRepository.save(task);
@@ -57,19 +58,24 @@ public class TaskCommandServiceImpl implements TaskCommandService {
 
     /**
      * 새로운 할 일의 position 을 계산합니다.
-     * 카테고리 내 task의 최대 position을 조회한 후,
-     * 없으면 0번, 있으면 max+1로 지정합니다.
+     * 특정 날짜와 카테고리 내 task의 최대 position을 조회한 후,
+     * 없으면 0, 있으면 max+1로 지정합니다.
      *
      * @param categoryId
+     * @param date
      * @return 새로운 할 일의 position
      */
-    private Integer generateNextPosition(Long categoryId) {
-        Integer max = taskRepository.findMaxPositionByCategoryId(categoryId);
+    private Integer generateNextPosition(Long categoryId, LocalDate date) {
+        Integer max = taskRepository.findTopByCategoryIdAndDueDateOrderByPositionDesc(categoryId, date);
         if (max == null) {
             log.debug("[TASK][generateNextPosition] max가 null이므로 기본값 0으로 시작합니다.");
             return 0;
         }
-        return max + 1;
+        int next = max + 1;
+        log.debug("[TASK][generateNextPosition] date={}, categoryId={} 의 max={} -> next={}",
+                date, categoryId, max, next);
+
+        return next;
     }
 
     /**


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
할일 등록 api에서 order 계산 방식이 날짜를 고려하지 않고 카테고리 별로 order를 계산하고 있음
-> 할일 등록시 categoryId, date를 사용하여 조회

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #107

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- 순서 생성 시 categoryId, date를 사용하여 조회

## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 